### PR TITLE
Update references to scripts and plugins directories in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,29 @@ Using IPC enables each plugin to isolate their data from other plugin processes 
 
 ## Plugin Directories
 
-- User-local plugins: `~/.local/share/pop-shell/plugins`
-- System-wide install for system administrators: `/etc/pop-shell/plugins`
-- Distribution packaging: `/usr/lib/pop-shell/plugins`
+- User-local plugins: `~/.local/share/pop-launcher/plugins`
+- System-wide install for system administrators: `/etc/pop-launcher/plugins`
+- Distribution packaging: `/usr/lib/pop-launcher/plugins`
 
 ## Script Directories
 
-- User-local scripts: `~/.local/share/pop-shell/scripts`
-- System-wide install for system administrators: `/etc/pop-shell/scripts`
-- Distribution packaging: `/usr/lib/pop-shell/scripts`
+- User-local scripts: `~/.local/share/pop-launcher/scripts`
+- System-wide install for system administrators: `/etc/pop-launcher/scripts`
+- Distribution packaging: `/usr/lib/pop-launcher/scripts`
+
+Example script
+<details>
+<pre>
+#!/bin/sh
+#
+# name: Connect to VPN
+# icon: network-vpn
+# description: Start VPN
+# keywords: vpn start connect
+
+nmcli connection up "vpn-name"
+</pre>
+</details>
 
 ## JSON IPC
 


### PR DESCRIPTION
Noticed that my scripts stopped working with a pop-os launcher today. I had to move the scripts to a new location.

Update the readme with the correct folders (according to https://github.com/pop-os/launcher/blob/master/plugins/src/scripts/mod.rs#L17)

Also added an example script (not sure if we can pass parameters, but adding one with parameters would be useful as well)