### PR TITLE
fix(service): Stale search results after interrupt

### DIFF
--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -322,6 +322,7 @@ impl<O: futures::Sink<Response> + Unpin> Service<O> {
             if !self.search_scheduled {
                 self.interrupt().await;
                 self.search_scheduled = true;
+                self.last_query = query;
             }
 
             return;


### PR DESCRIPTION
Closes #13 