### PR TITLE
fix(calc): Update description from JS to Rust dependency

### DIFF
--- a/plugins/src/calc/plugin.ron
+++ b/plugins/src/calc/plugin.ron
@@ -1,6 +1,6 @@
 (
     name: "Calculator",
-    description: "Math.JS calculations",
+    description: "Calculator with unit conversion (qalc)",
     query: (
         regex: "^(=)+",
         help: "= ",


### PR DESCRIPTION
You might want it to say something different though, but at least not Math.JS any longer :)