### PR TITLE
chore(plugins-web): Change aliases to address complaints

### DIFF
--- a/plugins/src/web/config.ron
+++ b/plugins/src/web/config.ron
@@ -5,7 +5,7 @@
             queries: [(name: "AliExpress", query: "aliexpress.com/wholesale?SearchText=")]
         ),
         (
-            matches: ["a", "amazon"],
+            matches: ["amazon"],
             queries: [(name: "Amazon", query: "smile.amazon.com/s?k=" )]
         ),
         (
@@ -17,7 +17,7 @@
             queries: [(name: "Bandcamp", query: "bandcamp.com/search?q=")]
         ),
         (
-            matches: ["b", "bing"],
+            matches: ["bing"],
             queries: [(name: "Bing", query: "bing.com/search?q=")]
         ),
         (
@@ -40,11 +40,11 @@
             queries: [(name: "Docs.rs", query: "docs.rs/")]
         ),
         (
-            matches: ["fh"],
+            matches: ["fh", "flathub"],
             queries: [(name: "Flathub", query: "flathub.org/apps/search/")]
         ),
         (
-            matches: ["gh"],
+            matches: ["gh", "github"],
             queries: [(name: "GitHub", query: "github.com/search?q=")]
         ),
         (
@@ -52,7 +52,7 @@
             queries: [(name: "GitHub Gist", query: "gist.github.com/search?q=")]
         ),
         (
-            matches: ["g", "google"],
+            matches: ["gs", "google"],
             queries: [(name: "Search", query: "google.com/search?q=")]
         ),
         (
@@ -104,11 +104,11 @@
             queries: [(name: "Wikipedia", query: "wikipedia.org/w/index.php?search=")]
         ),
         (
-            matches: ["yh"],
+            matches: ["yh", "yahoo"],
             queries: [(name: "Yahoo!", query: "search.yahoo.com/search?p=")]
         ),
         (
-            matches: ["yt"],
+            matches: ["yt", "youtube"],
             queries: [(name: "YouTube", query: "youtube.com/results?search_query=")]
         ),
     ]

--- a/plugins/src/web/plugin.ron
+++ b/plugins/src/web/plugin.ron
@@ -1,6 +1,6 @@
 (
     name: "Web search",
-    description: "Syntax: { ddg | g | b | ... } <keywords>\nExample: ddg how to install Pop!_OS",
+    description: "Syntax: { ddg | google | ... } <keywords>\nExample: ddg how to install Pop!_OS",
     query: (help: "ddg ", priority: High),
     bin: (path: "web"),
     icon: Name("system-search"),


### PR DESCRIPTION
People don't like that `a` features Amazon and `b` features Bing. I'm
sure the same could be said for `g` for Google. Single-character aliases
seem to be a bad idea. Other aliases could also use some improvements
to add additional obvious aliases.

https://www.reddit.com/r/pop_os/comments/r19195/pop_os_how_do_i_stop_the_shell_from_showing/