### PR TITLE
Remove "approx." keyword and improve decimal point/comma handling

### DIFF
--- a/plugins/src/calc/mod.rs
+++ b/plugins/src/calc/mod.rs
@@ -117,6 +117,7 @@ async fn qcalc(regex: &mut Regex, expression: &str, decimal_comma: bool) -> Opti
     let mut command = Command::new("qalc");
 
     command.args(&["-u8"]);
+    command.args(&["-set", "maxdeci 9"]);
 
     if decimal_comma {
         command.args(&["-set", "decimal comma on"]);
@@ -197,10 +198,10 @@ async fn qcalc(regex: &mut Regex, expression: &str, decimal_comma: bool) -> Opti
                 }
             }
 
-            let cut = if let Some(pos) = normalized.find('=') {
-                pos + 1
-            } else if let Some(pos) = normalized.find('≈') {
+            let cut = if let Some(pos) = normalized.rfind('≈') {
                 pos
+            } else if let Some(pos) = normalized.rfind('=') {
+                pos + 1
             } else {
                 return None;
             };
@@ -272,7 +273,7 @@ mod tests {
 
         smol::block_on(async {
             if let Some(result) = task.await {
-                assert_eq!("≈ 2.3333333", result);
+                assert_eq!("≈ 2.333333333", result);
             }
         })
     }

--- a/plugins/src/calc/mod.rs
+++ b/plugins/src/calc/mod.rs
@@ -200,7 +200,7 @@ async fn qcalc(regex: &mut Regex, expression: &str, decimal_comma: bool) -> Opti
             let cut = if let Some(pos) = normalized.find('=') {
                 pos + 1
             } else if let Some(pos) = normalized.find('≈') {
-                pos + '≈'.len_utf8()
+                pos
             } else {
                 return None;
             };
@@ -260,7 +260,7 @@ mod tests {
     }
 
     #[test]
-    fn no_approx_keyword_in_result() {
+    fn approximate_result_formatting() {
         let task = smol::spawn(async {
             let mut app = App {
                 decimal_comma: false,
@@ -272,7 +272,7 @@ mod tests {
 
         smol::block_on(async {
             if let Some(result) = task.await {
-                assert_eq!("2.3333333", result);
+                assert_eq!("≈ 2.3333333", result);
             }
         })
     }


### PR DESCRIPTION
This changes the calculator behavior to stop showing "approx." in front of numbers when it has more decimal places than can be shown, by enabling qalc's Unicode support. It also explicitly sets the decimal mark to decimal points when that's preferred over commas.

For issue #71 