### PR TITLE
feat(desktop-entries): Nix application paths support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "freedesktop-desktop-entry"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ecb2f63bfff12ca1a6e98c2ed7bac47169abe4d3cdbaeeb8e3852afdcc8ace"
+checksum = "bf77a18f5a7dc4fa975cb54cbb204abc04121131a92aa7010438d29e513bb1ae"
 dependencies = [
  "dirs",
  "gettext-rs",

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 async-pidfd = "0.1"
 fork = "0.1"
-freedesktop-desktop-entry = "0.4"
+freedesktop-desktop-entry = "0.4.1"
 futures-lite = "1"
 gtk = "0.14"
 human_format = "1.0"

--- a/plugins/src/desktop_entries/mod.rs
+++ b/plugins/src/desktop_entries/mod.rs
@@ -301,6 +301,8 @@ fn path_string(source: &PathSource) -> Cow<'static, str> {
     match source {
         PathSource::Local | PathSource::LocalDesktop => "Local".into(),
         PathSource::LocalFlatpak => "Flatpak".into(),
+        PathSource::LocalNix => "Nix".into(),
+        PathSource::Nix => "Nix (System)".into(),
         PathSource::System => "System".into(),
         PathSource::SystemFlatpak => "Flatpak (System)".into(),
         PathSource::SystemSnap => "Snap (System)".into(),


### PR DESCRIPTION
The Nix system path takes priority over the system path, but below Flatpak and Snap system paths, and the local nix path takes priority over all system paths, but below local Flatpak/Snap/.local paths.

To install nix in a multi-user capacity (system-wide):

```
sh <(curl -L https://nixos.org/nix/install) --daemon
```

Then you can install an application per-user and see it installed at `~/.nix-profile/share/applications`.

```
nix-env -i firefox
```

To install system-wide, switch to root and do the same and you'll find it installed in `/nix/var/nix/profiles/default/share/applications`

```
sudo su
bash
nix-env -i firefox
```
