### PR TITLE
fix(pop_shell): Implement 'Quit' request handler

### DIFF
--- a/plugins/src/pop_shell/mod.rs
+++ b/plugins/src/pop_shell/mod.rs
@@ -45,7 +45,7 @@ pub async fn main() {
         match request {
             Ok(request) => match request {
                 Request::Activate(id) => app.activate(id).await,
-                Request::Quit(_id) => (),
+                Request::Quit(id) => app.quit(id).await,
                 Request::Search(query) => app.search(&query).await,
                 Request::Exit => break,
                 _ => (),
@@ -95,6 +95,13 @@ impl<W: AsyncWrite + Unpin> App<W> {
         if let Some(id) = self.entries.get(id as usize) {
             let entity = id.entity;
             let _ = self.call_method("WindowFocus", &(entity,));
+        }
+    }
+
+    async fn quit(&mut self, id: u32) {
+        if let Some(id) = self.entries.get(id as usize) {
+            let entity = id.entity;
+            let _ = self.call_method("WindowQuit", &(entity,));
         }
     }
 


### PR DESCRIPTION
This addresses [an issue opened in the pop-os/shell repo](https://github.com/pop-os/shell/issues/1278) (is there a more convenient way to link to issues of a different project...?), where the ability to close an item in the launcher window via `Ctrl`+`Q` was lost, presumably after replacing the JS service with the Rust service.

The request handler for the *Quit* event of the *pop_shell* plugin just did nothing, instead of calling the `WindowQuit` function via D-Bus.

I am assuming this is just an oversight and there are no technical limitations preventing this (it seemed to work just fine when I tested it locally), hence this pull request :-)