### PR TITLE
fix(plugin): load desktop entries from user dir

### DIFF
--- a/plugins/src/desktop_entries/mod.rs
+++ b/plugins/src/desktop_entries/mod.rs
@@ -168,7 +168,7 @@ impl<W: AsyncWrite + Unpin> App<W> {
                                 src,
                             };
 
-                            deduplicator.replace(item);
+                            deduplicator.insert(item);
                         }
                     }
                 }


### PR DESCRIPTION
Currently the destkop-entry plugin retains the entries emitted by the freedesktop-desktop-entry crate in reverse order. 

For instance '$HOME/.local/share/applications/jetbrains-clion.desktop' is emitted first then 
overriden by '/usr/share/applications/jetbrains-clion.desktop'.  

Instead of `Hashset::replace`, `Hashset::insert` must be use to avoid overriding entries with higher priority. 

From freedesktop basedir specification: 
- " There is a set of preference ordered base directories relative to which data files should be searched. This set of directories is defined by the environment variable $XDG_DATA_DIRS." (see: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)

From desktop-entries specification: 
-  "If multiple files have the same desktop file ID, the first one in the $XDG_DATA_DIRS precedence order is used." (see: https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html)