### PR TITLE
feat: add a toolkit crate for both client and pop-launcher-bin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,8 +1075,7 @@ version = "1.2.1"
 dependencies = [
  "dirs 4.0.0",
  "mimalloc",
- "pop-launcher-plugins",
- "pop-launcher-service",
+ "pop-launcher-toolkit",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1141,6 +1140,15 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "pop-launcher-toolkit"
+version = "0.1.0"
+dependencies = [
+ "pop-launcher",
+ "pop-launcher-plugins",
+ "pop-launcher-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/pop-os/launcher"
 edition = "2018"
 
 [workspace]
-members = ["bin", "plugins", "service"]
+members = ["bin", "plugins", "service", "toolkit"]
 
 [dependencies]
 const_format = "0.2.22"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -8,8 +8,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pop-launcher-plugins = { path = "../plugins" }
-pop-launcher-service = { path = "../service" }
+pop-launcher-toolkit = { path = "../toolkit" }
 tracing = "0.1.32"
 tracing-subscriber = { version = "0.3.9", default-features = false, features = ["std", "fmt", "env-filter"] }
 dirs = "4.0.0"

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -1,8 +1,8 @@
 // Copyright 2021 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
 
-use pop_launcher_plugins as plugins;
-use pop_launcher_service as service;
+use pop_launcher_toolkit::plugins;
+use pop_launcher_toolkit::service;
 
 use mimalloc::MiMalloc;
 

--- a/plugins/src/web/config.rs
+++ b/plugins/src/web/config.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use slab::Slab;
 use std::collections::HashMap;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Config {
     matches: HashMap<String, u32>,
     queries: Slab<Vec<Definition>>,
@@ -29,18 +29,18 @@ impl Config {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct RawConfig {
     pub rules: Vec<Rule>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Rule {
     pub matches: Vec<String>,
     pub queries: Vec<Definition>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Definition {
     pub name: String,
     pub query: String,

--- a/plugins/src/web/mod.rs
+++ b/plugins/src/web/mod.rs
@@ -12,11 +12,10 @@ use url::Url;
 
 use pop_launcher::*;
 
-use self::config::{Config, Definition};
+pub use config::{Config, Definition, load};
 use regex::Regex;
 
 mod config;
-
 pub async fn main() {
     let mut app = App::default();
 

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -5,6 +5,8 @@ mod client;
 mod plugins;
 
 pub use client::*;
+pub use plugins::config;
+pub use plugins::external::load;
 
 use crate::plugins::*;
 use flume::{Receiver, Sender};

--- a/service/src/plugins/config.rs
+++ b/service/src/plugins/config.rs
@@ -8,7 +8,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, Clone)]
 pub struct PluginConfig {
     pub name: Cow<'static, str>,
     pub description: Cow<'static, str>,
@@ -29,7 +29,7 @@ pub struct PluginConfig {
     pub query: PluginQuery,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, Clone)]
 pub struct PluginBinary {
     path: Cow<'static, str>,
 
@@ -38,7 +38,7 @@ pub struct PluginBinary {
     args: Vec<Cow<'static, str>>,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, Clone)]
 pub struct PluginQuery {
     #[serde(
         default,

--- a/service/src/plugins/mod.rs
+++ b/service/src/plugins/mod.rs
@@ -1,9 +1,11 @@
 // Copyright 2021 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
 
-mod config;
 pub(crate) mod external;
+pub mod config;
 pub mod help;
+
+pub use external::load;
 
 pub use self::config::{PluginBinary, PluginConfig, PluginPriority, PluginQuery};
 pub use self::external::ExternalPlugin;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,13 +44,13 @@ pub type Generation = u32;
 /// u32 value defining the indice of a slot.
 pub type Indice = u32;
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ContextOption {
     pub id: Indice,
     pub name: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub enum GpuPreference {
     Default,
     NonDefault,
@@ -65,7 +65,7 @@ pub enum IconSource {
 }
 
 /// Sent from a plugin to the launcher service.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub enum PluginResponse {
     /// Append a new search item to the launcher.
     Append(PluginSearchResult),
@@ -92,7 +92,7 @@ pub enum PluginResponse {
 }
 
 /// Search information from a plugin to be sorted and filtered by the launcher service.
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct PluginSearchResult {
     /// Numeric identifier tracked by the plugin.
     pub id: Indice,
@@ -111,7 +111,7 @@ pub struct PluginSearchResult {
 }
 
 // Sent to the input pipe of the launcher service, and disseminated to its plugins.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub enum Request {
     /// Activate on the selected item.
     Activate(Indice),
@@ -132,7 +132,7 @@ pub enum Request {
 }
 
 /// Sent from the launcher service to a frontend.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub enum Response {
     // An operation was performed and the frontend may choose to exit its process.
     Close,
@@ -153,7 +153,7 @@ pub enum Response {
 }
 
 /// Serialized response to launcher frontend about a search result.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SearchResult {
     /// Numeric identifier tracked by the plugin.
     pub id: Indice,

--- a/toolkit/Cargo.toml
+++ b/toolkit/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "pop-launcher-toolkit"
+version = "0.1.0"
+edition = "2021"
+description = "A wrapper around pop-launcher, pop-launcher-service and pop-launcher-plugins types for writing plugins and frontends for pop-launcher."
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+pop-launcher-plugins = { path = "../plugins"}
+pop-launcher-service = { path = "../service"}
+pop-launcher = { path = "../" }

--- a/toolkit/src/lib.rs
+++ b/toolkit/src/lib.rs
@@ -1,0 +1,10 @@
+// Copyright 2021 System76 <info@system76.com>
+// SPDX-License-Identifier: MPL-2.0
+
+pub use pop_launcher_service::{
+    self as service,
+    load::from_path as load_plugin_from_path,
+    load::from_paths as load_plugins_from_paths
+};
+pub use pop_launcher_plugins as plugins;
+pub use pop_launcher as launcher;


### PR DESCRIPTION
This PR add the crate pop-launcher-toolkit which mostly reexport types needed to write a pop-launcher client and allow to 
add global features.  

## Motivation

Using only the pop-launcher bring just the minimal set of features required to build a client. 
Unfortunately this is not enough to implement some features. Cosmic-launcher make use of both the pop-launcher and the pop-launcher-service crates, onagre use them all. 

Since most client and plugin implementations will use more than the pop-launcher crate we might as well expose everything in a wrapper crate. It make things much easier for the developer and documentation is available in one place. 
 
## Changes

1. Most of the configs related struct  and utility functions are now public 
  I am using this in onagre to get the plugin regex and highlight the search input that trigger the plugin activation. This unlock many cllient side features (switching between plugins with tab, displaying the icons before querying pop-launcher, dynamic plugin menu, a plugin config editor  etc..).

2. Added a "clone" feature
  This is a bit selfish but iced has some trait that requires `Clone` to send stuffs between threads, I guess other GUI libs have similar requirements. It's a pain to wrap everything in unit structs just to manually implement clone.  

## Dependecy graph (pop-launcher-bin) 

![image](https://user-images.githubusercontent.com/24563836/167865753-f5bd4b04-a4eb-4782-8926-de8f3dbd0850.png)

Let me know what you think.

 