### PR TITLE
fix(web): Prevent overwriting of keywords

### DIFF
--- a/plugins/src/web/config.rs
+++ b/plugins/src/web/config.rs
@@ -16,7 +16,7 @@ impl Config {
         for rule in rules.rules {
             let idx = self.queries.insert(rule.queries);
             for keyword in rule.matches {
-                self.matches.insert(keyword, idx as u32);
+                self.matches.entry(keyword).or_insert(idx as u32);
             }
         }
     }


### PR DESCRIPTION
While the configs come in, in the correct order (User, System, Distro), inside of the web plugin, keywords are overwritten by later keywords. This prevents the overwriting of already present keywords.

Follows clippy lint convention: https://rust-lang.github.io/rust-clippy/master/#map_entry

Fixes #125 