### PR TITLE
feat(web): specify icon

### DIFF
--- a/plugins/src/web/config.rs
+++ b/plugins/src/web/config.rs
@@ -44,6 +44,8 @@ pub struct Rule {
 pub struct Definition {
     pub name: String,
     pub query: String,
+    #[serde(default)]
+    pub icon: String,
 }
 
 pub fn load() -> Config {


### PR DESCRIPTION
Some favicons are only provided with a resolution of 16x16, resulting in the logo being rather muddy inside of pop-launcher.

WIth this pull-request some changes were made.
- The Definition-Struct was extended with the icon-variable, which does not need to be defined.
  - If it is defined, it is prioritized as a candidate for the downloaded icon.
- The cascading fallback icon download match-cases were replaced with a List of icon sources.
  - The first successful icon of this list is used. 


As an example Nix Packages can be used
```
(
   matches: ["np"],
   queries: [(name: "Nix Packages", query: "search.nixos.org/packages?channel=unstable&query=")]
),
```
With this a rather muddy looking icon is used.
But should we use this instead:
```
(
   matches: ["np"],
   queries: [(
      name: "Nix Packages", 
      query: "search.nixos.org/packages?channel=unstable&query=",
      icon: "https://nixos.wiki/nixos-logo-small.png",
   )]
),
```
A more crisp looking icon is used instead.

I am not to proud of the for-loop, processing the icon_sources-list.
The alternative would be to convert the icon_sources-list to a [futures stream](https://docs.rs/futures/latest/futures/stream/trait.StreamExt.html), but this introduced some problems and made it less obvious what is happening.