### PR TITLE
add startpage to config.ron

### DIFF
--- a/plugins/src/web/config.ron
+++ b/plugins/src/web/config.ron
@@ -107,6 +107,10 @@
             matches: ["stack"],
             queries: [(name: "Stack Overflow", query: "stackoverflow.com/search?q=")]
         ),
+	(
+	    matches: ["sp", "starpage"],
+	    queries: [(name: "Startpage", query: "https://www.startpage.com/sp/search?query=")]
+	),
         (
             matches: ["twitch"],
             queries: [(name: "Twitch", query: "twitch.tv/search?term=")]

--- a/plugins/src/web/config.ron
+++ b/plugins/src/web/config.ron
@@ -109,7 +109,7 @@
         ),
 	(
 	    matches: ["sp", "starpage"],
-	    queries: [(name: "Startpage", query: "https://www.startpage.com/sp/search?query=")]
+	    queries: [(name: "Startpage", query: "startpage.com/sp/search?query=")]
 	),
         (
             matches: ["twitch"],

--- a/plugins/src/web/config.ron
+++ b/plugins/src/web/config.ron
@@ -108,7 +108,7 @@
             queries: [(name: "Stack Overflow", query: "stackoverflow.com/search?q=")]
         ),
 	(
-	    matches: ["sp", "starpage"],
+	    matches: ["sp", "startpage"],
 	    queries: [(name: "Startpage", query: "startpage.com/sp/search?query=")]
 	),
         (


### PR DESCRIPTION
I was missing starpage in pop launcher so I added it into 'launcher/plugins/src/web/config.ron' with either prompt 'sp' or 'startpage'.