### PR TITLE
Add MDN docs to list of web search shortcuts

### DIFF
--- a/plugins/src/web/config.ron
+++ b/plugins/src/web/config.ron
@@ -83,6 +83,10 @@
             matches: ["lib"],
             queries: [(name: "Libraries.io", query: "libraries.io/search?q=")]
         ),
+	(
+	    matches: ["mdn"],
+	    queries: [(name: "Mozilla Developer Network", query: "developer.mozilla.org/search?q=")]
+	),
         (
             matches: ["npm"],
             queries: [(name: "npm", query: "npmjs.com/search?q=")]


### PR DESCRIPTION
Hello! I was pleasantly surprised to see the Pop launcher has lots of handy shortcuts for searching developer documentation sites, but was sad when I saw that https://developer.mozilla.org, arguably the go-to documentation site for web developers, didn't have a shortcut.

This pull request fixes that :)