### PR TITLE
Add poweroff keyword to session-shutdown.sh and sleep keyword to session-suspend.sh

### DIFF
--- a/scripts/session/session-shutdown.sh
+++ b/scripts/session/session-shutdown.sh
@@ -3,6 +3,6 @@
 # name: Power off
 # icon: system-shutdown
 # description: Shut down the system
-# keywords: power off shutdown
+# keywords: power off shutdown poweroff
 
 gnome-session-quit --power-off

--- a/scripts/session/session-suspend.sh
+++ b/scripts/session/session-suspend.sh
@@ -3,6 +3,6 @@
 # name: Suspend
 # icon: system-suspend
 # description: Suspend the system
-# keywords: suspend
+# keywords: suspend sleep
 
 systemctl suspend


### PR DESCRIPTION
`poweroff` is the command used in the terminal, and `sleep` will be what Windows users will likely be used to. Apologies if this PR is unnecessary.