### PR TITLE
Add Google Scholar to the search engines.

### DIFF
--- a/plugins/src/web/config.ron
+++ b/plugins/src/web/config.ron
@@ -80,7 +80,7 @@
             queries: [(name: "News", query: "google.com/news?q=")]
         ),
         (
-            matches: ["gsc", scholar"],
+            matches: ["gsc", "scholar"],
             queries: [(name: "Google Scholar", query: "google.com/scholar?q=")]
         ),
         (

--- a/plugins/src/web/config.ron
+++ b/plugins/src/web/config.ron
@@ -79,6 +79,10 @@
             matches: ["gn"],
             queries: [(name: "News", query: "google.com/news?q=")]
         ),
+	(
+            matches: ["gsc", scholar"],
+            queries: [(name: "Google Scholar", query: "google.com/scholar?q=")]
+        ),
         (
             matches: ["lib"],
             queries: [(name: "Libraries.io", query: "libraries.io/search?q=")]

--- a/plugins/src/web/config.ron
+++ b/plugins/src/web/config.ron
@@ -79,7 +79,7 @@
             matches: ["gn"],
             queries: [(name: "News", query: "google.com/news?q=")]
         ),
-	(
+        (
             matches: ["gsc", scholar"],
             queries: [(name: "Google Scholar", query: "google.com/scholar?q=")]
         ),


### PR DESCRIPTION
I would like to search google scholar through the pop os launcher. The matches are subject to discussion, I typically use `scholar`, but DuckDuckGo uses the `!gsc` shortcut, so I added that as well.