### PR TITLE
fix: allow web plugin to xdg-open custom URI schemes #154

### DIFF
--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -13,7 +13,7 @@ pub mod terminal;
 pub mod web;
 
 use pop_launcher::PluginResponse;
-use std::{borrow::Cow, ffi::OsStr, future::Future, path::Path};
+use std::{borrow::Cow, ffi::OsStr, future::Future, path::Path, process::Stdio};
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 pub async fn send<W: AsyncWrite + Unpin>(tx: &mut W, response: PluginResponse) {
@@ -47,5 +47,9 @@ pub fn mime_from_path(path: &Path) -> Cow<'static, str> {
 
 /// Launches a file with its default appplication via `xdg-open`.
 pub fn xdg_open<S: AsRef<OsStr>>(file: S) {
-    let _ = tokio::process::Command::new("xdg-open").arg(file).spawn();
+    let _ = tokio::process::Command::new("xdg-open")
+        .arg(file)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
 }

--- a/plugins/src/web/mod.rs
+++ b/plugins/src/web/mod.rs
@@ -199,7 +199,9 @@ impl App {
 fn build_query(definition: &Definition, query: &str) -> String {
     let q = definition.query.as_str();
 
-    let prefix = if q.starts_with("https://") || q.starts_with("http://") {
+    let scheme_regex = Regex::new(r"^([a-zA-Z]+[a-zA-Z0-9\+\-\.]*):").unwrap();
+
+    let prefix = if scheme_regex.is_match(q) {
         ""
     } else {
         "https://"


### PR DESCRIPTION
Prevents prefixing `https://` to custom URI schemes

Fixes #154 