### PR TITLE
fix(web): Ignore invalid URLs rather than panicking

### DIFF
--- a/plugins/src/web/mod.rs
+++ b/plugins/src/web/mod.rs
@@ -131,12 +131,9 @@ impl App {
         let client = self.client.clone();
 
         let query = build_query(def, "");
-        let url = match Url::parse(&query) {
-            Ok(parsed) => parsed,
-            Err(_) => {
-                // return early if passed an invalid url, e.g. 'http://'
-                return;
-            }
+        let Ok(url) = Url::parse(&query) else {
+            // return early if passed an invalid url, e.g. 'http://'
+            return;
         };
 
         let icon_source = def.icon.clone();

--- a/plugins/src/web/mod.rs
+++ b/plugins/src/web/mod.rs
@@ -130,14 +130,21 @@ impl App {
     async fn fetch_icon_in_background(&self, def: &Definition, favicon_path: &Path) {
         let client = self.client.clone();
 
-        let url = build_query(def, "");
-        let url = Url::parse(&url).expect("invalid url");
+        let query = build_query(def, "");
+        let url = match Url::parse(&query) {
+            Ok(parsed) => parsed,
+            Err(_) => {
+                // return early if passed an invalid url, e.g. 'http://'
+                return;
+            }
+        };
+
         let icon_source = def.icon.clone();
 
         let domain = url
             .domain()
             .map(|domain| domain.to_string())
-            .expect("url have no domain");
+            .expect("url has no domain");
 
         let favicon_path = favicon_path.to_path_buf();
 


### PR DESCRIPTION
This fixes an issue where the launcher panics if given an invalid URL. Precondition to PR #156 working as expected.

Note that this fix prevents another (possibly bad) issue: if the launcher panics while fetching an icon image to the cache, a corrupt image may be stored. Subsequent uses of pop-launcher could attempt to display the corrupted (cached) image, resulting in either a garbled image or, perhaps, undefined behavior.