### PR TITLE
feat(pop_shell): add config with window name/description search scope

### DIFF
--- a/plugins/src/pop_shell/config.rs
+++ b/plugins/src/pop_shell/config.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright © 2021 System76
+
+use serde::Deserialize;
+
+pub fn bool_true() -> bool {
+    true
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct SearchScope {
+    #[serde(default = "bool_true")]
+    pub name: bool,
+
+    #[serde(default = "bool_true")]
+    pub description: bool,
+}
+
+impl Default for SearchScope {
+    fn default() -> SearchScope {
+        SearchScope {
+            name: true,
+            description: true,
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Clone)]
+pub struct Config {
+    #[serde(default)]
+    pub search: SearchScope,
+}
+
+pub fn load() -> Config {
+    let mut config = Config::default();
+
+    for path in pop_launcher::config::find("pop_shell") {
+        let string = match std::fs::read_to_string(&path) {
+            Ok(string) => string,
+            Err(why) => {
+                tracing::error!("failed to read config: {}", why);
+                continue;
+            }
+        };
+
+        match ron::from_str::<Config>(&string) {
+            Ok(raw) => config.search = raw.search,
+            Err(why) => {
+                tracing::error!("failed to deserialize config: {}", why);
+            }
+        }
+    }
+
+    config
+}


### PR DESCRIPTION
This adds an optional `config.ron` file to the `pop_shell` plugin and allows users to configure what desktop window attributes they want searched (e.g. window title and/or window description).

For example, I prefer the window name not to be searched, because it's often a web page that has set the title of the window (e.g. in Chromium). Because window items in the launcher list always sort above desktop apps, these active window HTML pages can get in the way of fast/memory muscle launcher usage.

My config is as follows (`~/.local/share/pop-launcher/plugins/pop_shell/config.ron`):

```ron
(
    search: (name: false, description: true),
)
```

With the above config, even if I'm on a google search page for `xournal++`, typing `xou` into pop-launcher will always load my desktop app, "Xournal++", even if a Chromium HTML page has set the title to "Xournal++ Search Results". (Typing "chro", however, would still switch to Chromium).

The default remains as it was, effectively:

```ron
(
    search: (name: true, description: true),
)
```

Fixes #152 