### PR TITLE
feat(find): let fdfind use --full-path search to include directories

### DIFF
--- a/plugins/src/find/mod.rs
+++ b/plugins/src/find/mod.rs
@@ -223,6 +223,7 @@ async fn query(arg: &str) -> io::Result<(Child, ChildStdout)> {
     let spawn = |cmd: &str| -> io::Result<Child> {
         Command::new(cmd)
             .arg("-i")
+            .arg("--full-path")
             .arg(arg)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())


### PR DESCRIPTION
Allows the user to find files within directories. Useful when files with the same name are found in many directories, e.g. `package.json`:

```
find MyProject/package.json
```

Fixes #150 