### PR TITLE
use xdg-screensaver in session-lock script for cross compatibility

### DIFF
--- a/scripts/session/session-lock.sh
+++ b/scripts/session/session-lock.sh
@@ -7,4 +7,4 @@
 
 set -eu
 
-dbus-send --type=method_call --dest=org.gnome.ScreenSaver /org/gnome/ScreenSaver org.gnome.ScreenSaver.Lock
+xdg-screensaver lock


### PR DESCRIPTION
This change is based on comments from the original PR #166.

https://github.com/pop-os/launcher/commit/970e71e2beec1a381e879e5df6652b47f6a017e0#commitcomment-98615497

https://github.com/pop-os/launcher/commit/970e71e2beec1a381e879e5df6652b47f6a017e0#commitcomment-98616065

In my initial testing with using `xdg-screensaver` I saw it fail a few times on the `lemp11`. This my have been a one off, but should be tested for.