### PR TITLE
fix: deactivate cosmic plugin when not in a COSMIC session

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
     "remote.containers.dockerPath": "podman",
-    "rust-analyzer.checkOnSave.command": "clippy",
-    "rust-analyzer.checkOnSave.extraArgs": ["--", "-W", "clippy::pedantic"]
+    "rust-analyzer.check.overrideCommand": ["just", "check-json"]
 }

--- a/README.md
+++ b/README.md
@@ -20,16 +20,19 @@ And then must be used with a compatible pop-launcher frontend
 - [onagre](https://github.com/oknozor/onagre)
 
 ```sh
-just # Build
+just build-release # Build
 just install # Install locally
 ```
 
-Packaging for a Linux distribution?
+If you are packaging, run `just vendor` outside of your build chroot, then use `just build-vendored` inside the build-chroot. Then you can specify a custom root directory and prefix.
 
 ```sh
-just vendor # Vendor
-just vendor=1 # Build with vendored dependencies
-just rootdir=$(DESTDIR) install # Install to custom root directory
+# Outside build chroot
+just vendor
+
+# Inside build chroot
+just build-vendored
+sudo just rootdir=debian/tmp prefix=/usr install
 ```
 
 Want to install specific plugins? Remove the plugins you don't want:

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends:
     cargo,
     debhelper-compat (=10),
     just,
-    pkgconf,
+    pkg-config,
     rustc (>=1.65),
     libxkbcommon-dev,
     libegl-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -25,7 +25,7 @@ override_dh_auto_clean:
 	fi
 
 override_dh_auto_build:
-	env CARGO_HOME="$$(pwd)/target/cargo" just rootdir=$(DESTDIR) debug=$(DEBUG) vendor=$(VENDOR)
+	just rootdir=$(DESTDIR) build-vendored
 
 override_dh_auto_install:
 	just rootdir=$(DESTDIR) install

--- a/debian/source/options
+++ b/debian/source/options
@@ -1,0 +1,2 @@
+tar-ignore=target
+tar-ignore=vendor

--- a/plugins/src/cosmic_toplevel/mod.rs
+++ b/plugins/src/cosmic_toplevel/mod.rs
@@ -26,7 +26,7 @@ pub async fn main() {
 
     let mut tx = async_stdout();
 
-    if session_is_cosmic() {
+    if !session_is_cosmic() {
         send(&mut tx, PluginResponse::Deactivate).await;
         return;
     }


### PR DESCRIPTION
This change will ensure that the cosmic plugin is deactivated if the launcher is not in a COSMIC session. It checks if `XDG_CURRENT_DESKTOP` contains `COSMIC` to do so.

Fixes #169 