### PR TITLE
[WIP] Flexible search plugin (via Unix pipes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,6 +1534,8 @@ dependencies = [
  "ron",
  "serde",
  "serde_json",
+ "shell-words",
+ "shellexpand",
  "slab",
  "strsim",
  "sysfs-class",
@@ -1969,6 +1971,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shellexpand"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1c7ddea665294d484c39fd0c0d2b7e35bbfe10035c5fe1854741a57f6880e1"
+dependencies = [
+ "dirs 4.0.0",
 ]
 
 [[package]]

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -20,8 +20,8 @@ async fn main() {
         match cmd {
             "calc" => plugins::calc::main().await,
             "desktop-entries" => plugins::desktop_entries::main().await,
-            "find" => plugins::find::main().await,
             "files" => plugins::files::main().await,
+            "search" => plugins::search::main().await,
             "pop-launcher" => service::main().await,
             "pop-shell" => plugins::pop_shell::main().await,
             "pulse" => plugins::pulse::main().await,

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -33,6 +33,8 @@ dirs = "4.0.0"
 futures = "0.3.25"
 bytes = "1.2.1"
 recently-used-xbel = "1.0.0"
+shell-words = "1.1.0"
+shellexpand = "3.0.0"
 
 # dependencies cosmic toplevel
 cctk = { git = "https://github.com/pop-os/cosmic-protocols", package = "cosmic-client-toolkit" }

--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -6,6 +6,7 @@ pub mod cosmic_toplevel;
 pub mod desktop_entries;
 pub mod files;
 pub mod find;
+pub mod search;
 pub mod pop_shell;
 pub mod pulse;
 pub mod recent;

--- a/plugins/src/search/app.rs
+++ b/plugins/src/search/app.rs
@@ -1,0 +1,245 @@
+use flume::Receiver;
+use regex::Regex;
+use std::cell::Cell;
+// use std::future::Future;
+use std::io;
+// use std::ops::Deref;
+use std::rc::Rc;
+// use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, BufReader, Lines};
+use tokio::process::ChildStdout;
+
+use pop_launcher::{async_stdout, PluginResponse, PluginSearchResult};
+
+use crate::search::config::Definition;
+use crate::search::util::interpolate_result;
+
+use super::config::{load, Config, DisplayLine};
+use super::util::{exec, interpolate_command};
+
+/// Maintains state for search requests
+pub struct App {
+    pub config: Config,
+
+    // Indicates if a search is being performed in the background.
+    pub active: Rc<Cell<bool>>,
+
+    // Flume channel where we can send interrupt
+    pub cancel: Option<flume::Receiver<()>>,
+
+    pub out: tokio::io::Stdout,
+    pub search_results: Vec<String>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            config: load(),
+            search_results: Vec::with_capacity(128),
+            active: Rc::new(Cell::new(false)),
+            cancel: None,
+            out: async_stdout(),
+        }
+    }
+}
+
+impl App {
+    pub async fn make_listener(
+        &mut self,
+        defn: &Definition,
+        stdout: &mut Lines<BufReader<ChildStdout>>,
+        search_terms: &[String],
+    ) {
+        let mut id = 0;
+        let mut append;
+        eprintln!("start listener");
+
+        'stream: loop {
+            let interrupt = async {
+                let x: Option<&Receiver<()>> = self.cancel.as_ref();
+                // let x: Option<&Receiver<()>> = (*cancel).as_ref();
+
+                if let Some(cancel) = x {
+                    let _ = cancel.recv_async().await;
+                } else {
+                    eprintln!("no interrupt receiver");
+                    tracing::error!("no interrupt receiver");
+                }
+                Ok(None)
+            };
+
+            match crate::or(interrupt, stdout.next_line()).await {
+                Ok(Some(line)) => {
+                    eprintln!("append line: {}", line);
+                    append = line
+                }
+                Ok(None) => {
+                    eprintln!("listener; break stream");
+                    break 'stream;
+                }
+                Err(why) => {
+                    eprintln!("error on stdout line read: {}", why);
+                    tracing::error!("error on stdout line read: {}", why);
+                    break 'stream;
+                }
+            }
+
+            self.append(id, &append, defn, search_terms).await;
+
+            id += 1;
+
+            if id == 10 {
+                break 'stream;
+            }
+        }
+    }
+
+    /// Appends a new search result to the context.
+    pub async fn append<'a>(
+        &mut self,
+        id: u32,
+        line: &'a str,
+        defn: &'a Definition,
+        vars: &'a [String],
+    ) {
+        eprintln!("append: {:?} {:?}", id, line);
+
+        let match_display_line = |display_line: &'a DisplayLine| -> Option<String> {
+            match display_line {
+                DisplayLine::Label(label) => Some(label.clone()),
+                DisplayLine::Capture(pattern) => {
+                    if let Ok(re) = Regex::new(&pattern) {
+                        re.captures(&line)
+                            .and_then(|caps| caps.get(1))
+                            .map(|cap| cap.as_str().to_owned())
+                    } else {
+                        tracing::error!("failed to build Capture regex: {}", pattern);
+
+                        None
+                    }
+                }
+                DisplayLine::Replace(pattern, replace) => {
+                    if let Ok(re) = Regex::new(&pattern) {
+                        if let Some(capture) = re
+                            .captures(&line)
+                            .and_then(|caps| caps.get(1))
+                            .map(|cap| cap.as_str())
+                        {
+                            let replacement = interpolate_result(replace, &vars, capture);
+                            if let Ok(replacement) = replacement {
+                                Some(replacement)
+                            } else {
+                                tracing::error!(
+                                    "unable to interpolate Replace: {}, {}",
+                                    pattern,
+                                    replace
+                                );
+
+                                None
+                            }
+                        } else {
+                            None
+                        }
+                    } else {
+                        tracing::error!("failed to build Replace regex: {}", pattern);
+
+                        None
+                    }
+                }
+            }
+        };
+
+        let title: Option<String> = match_display_line(&defn.title);
+        let detail: Option<String> = match_display_line(&defn.detail);
+
+        if let Some(title) = title {
+            if let Some(detail) = detail {
+                let response = PluginResponse::Append(PluginSearchResult {
+                    id,
+                    name: title.to_owned(),
+                    description: detail.to_owned(),
+                    ..Default::default()
+                });
+
+                eprintln!("append; send response {:?}", response);
+
+                crate::send(&mut self.out, response).await;
+                self.search_results.push(line.to_string());
+            }
+        }
+    }
+
+    /// Submits the query to `fdfind` and actively monitors the search results while handling interrupts.
+    pub async fn search(&mut self, search: String) {
+        eprintln!("config: {:?}", self.config);
+
+        self.search_results.clear();
+
+        if let Some(search_terms) = shell_words::split(&search).ok().as_deref() {
+            if let Some(word) = search_terms.first() {
+                eprintln!("look for word: '{}'", word);
+
+                let word_defn: Option<Definition> = self.config.get(word).cloned();
+
+                if let Some(defn) = word_defn {
+                    if let Some(parts) = interpolate_command(&defn.query, search_terms).ok() {
+                        eprintln!("search parts: {:?}", parts);
+
+                        if let Some((program, args)) = parts.split_first() {
+                            // We're good to exec the command!
+
+                            let (mut child, mut stdout) = match exec(program, args).await {
+                                Ok((child, stdout)) => {
+                                    eprintln!("spawned process");
+                                    (child, tokio::io::BufReader::new(stdout).lines())
+                                }
+                                Err(why) => {
+                                    eprintln!("failed to spawn process: {}", why);
+                                    tracing::error!("failed to spawn process: {}", why);
+
+                                    let _ = crate::send(
+                                        &mut self.out,
+                                        PluginResponse::Append(PluginSearchResult {
+                                            id: 0,
+                                            name: if why.kind() == io::ErrorKind::NotFound {
+                                                String::from("command not found")
+                                            } else {
+                                                format!("failed to spawn process: {}", why)
+                                            },
+                                            ..Default::default()
+                                        }),
+                                    )
+                                    .await;
+
+                                    return;
+                                }
+                            };
+
+                            let timeout = async {
+                                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                            };
+
+                            let listener = self.make_listener(&defn, &mut stdout, search_terms);
+
+                            futures::pin_mut!(timeout);
+                            futures::pin_mut!(listener);
+
+                            let _ = futures::future::select(timeout, listener).await;
+
+                            let _ = child.kill().await;
+                            let _ = child.wait().await;
+                        }
+                    } else {
+                        eprintln!("can't interpolate command");
+                    }
+                } else {
+                    eprintln!("no matching definition");
+                }
+            } else {
+                eprintln!("search term has no head word");
+            }
+        } else {
+            eprintln!("can't split search terms");
+        }
+    }
+}

--- a/plugins/src/search/app.rs
+++ b/plugins/src/search/app.rs
@@ -50,7 +50,6 @@ impl App {
     ) {
         let mut id = 0;
         let mut output_line;
-        eprintln!("start listener");
 
         'stream: loop {
             let interrupt = async {
@@ -59,7 +58,6 @@ impl App {
                 if let Some(cancel) = x {
                     let _ = cancel.recv_async().await;
                 } else {
-                    eprintln!("no interrupt receiver");
                     tracing::error!("no interrupt receiver");
                 }
                 Ok(None)
@@ -67,15 +65,12 @@ impl App {
 
             match crate::or(interrupt, stdout.next_line()).await {
                 Ok(Some(line)) => {
-                    eprintln!("append line: {}", line);
                     output_line = line
                 }
                 Ok(None) => {
-                    eprintln!("listener; break stream");
                     break 'stream;
                 }
                 Err(why) => {
-                    eprintln!("error on stdout line read: {}", why);
                     tracing::error!("error on stdout line read: {}", why);
                     break 'stream;
                 }
@@ -101,8 +96,6 @@ impl App {
         query_string: &'a str,
         keywords: &'a [String],
     ) {
-        eprintln!("append: {:?} {:?}", id, output_line);
-
         if let Ok(re) = Regex::new(&defn.output_captures) {
             if let Some(captures) = re.captures(&output_line) {
                 let interpolate = |result_line: &'a str| -> Option<String> {
@@ -144,8 +137,6 @@ impl App {
                                 description: description.to_owned(),
                                 ..Default::default()
                             });
-
-                            eprintln!("append; send response {:?}", response);
 
                             crate::send(&mut self.out, response).await;
                             self.search_results.push(run_command_parts);

--- a/plugins/src/search/app.rs
+++ b/plugins/src/search/app.rs
@@ -106,8 +106,10 @@ impl App {
 
         let match_display_line = |display_line: &'a DisplayLine| -> Option<String> {
             match display_line {
+                DisplayLine::Blank => Some("".to_string()),
+                DisplayLine::Echo => Some(line.to_string()),
                 DisplayLine::Label(label) => Some(label.clone()),
-                DisplayLine::Capture(pattern) => {
+                DisplayLine::CaptureOne(pattern) => {
                     if let Ok(re) = Regex::new(&pattern) {
                         re.captures(&line)
                             .and_then(|caps| caps.get(1))
@@ -118,7 +120,7 @@ impl App {
                         None
                     }
                 }
-                DisplayLine::Replace(pattern, replace) => {
+                DisplayLine::CaptureMany(pattern, replace) => {
                     if let Ok(re) = Regex::new(&pattern) {
                         if let Some(capture) = re
                             .captures(&line)
@@ -149,8 +151,8 @@ impl App {
             }
         };
 
-        let title: Option<String> = match_display_line(&defn.title);
-        let detail: Option<String> = match_display_line(&defn.detail);
+        let title: Option<String> = match_display_line(&defn.name);
+        let detail: Option<String> = match_display_line(&defn.description);
 
         if let Some(title) = title {
             if let Some(detail) = detail {

--- a/plugins/src/search/app.rs
+++ b/plugins/src/search/app.rs
@@ -127,6 +127,7 @@ impl App {
                     keywords,
                     &captures,
                 );
+                eprintln!("run command: {:?}", run_command_parts);
 
                 if let Some(name) = result_name {
                     if let Some(description) = result_desc {

--- a/plugins/src/search/app.rs
+++ b/plugins/src/search/app.rs
@@ -130,48 +130,6 @@ impl App {
                 None
             }
         };
-        // let match_display_line = |display_line: &'a DisplayLine| -> Option<String> {
-        //     match display_line {
-        //         DisplayLine::Blank => Some("".to_string()),
-        //         DisplayLine::Echo => Some(line.to_string()),
-        //         DisplayLine::Label(label) => Some(label.clone()),
-        //         DisplayLine::CaptureOne(pattern) => {
-        //             if let Ok(re) = Regex::new(&pattern) {
-        //                 re.captures(&line)
-        //                     .and_then(|caps| caps.get(1))
-        //                     .map(|cap| cap.as_str().to_owned())
-        //             } else {
-        //                 tracing::error!("failed to build Capture regex: {}", pattern);
-
-        //                 None
-        //             }
-        //         }
-        //         DisplayLine::CaptureMany(pattern, replace) => {
-        //             if let Ok(re) = Regex::new(&pattern) {
-        //                 if let Some(captures) = re.captures(&line) {
-        //                     let replacement = interpolate_result(replace, &keywords, &captures);
-        //                     if let Ok(replacement) = replacement {
-        //                         Some(replacement)
-        //                     } else {
-        //                         tracing::error!(
-        //                             "unable to interpolate Replace: {}, {}",
-        //                             pattern,
-        //                             replace
-        //                         );
-
-        //                         None
-        //                     }
-        //                 } else {
-        //                     None
-        //                 }
-        //             } else {
-        //                 tracing::error!("failed to build Replace regex: {}", pattern);
-
-        //                 None
-        //             }
-        //         }
-        //     }
-        // };
 
         let result_name: Option<String> = interpolate(&defn.result_name);
         let result_desc: Option<String> = interpolate(&defn.result_desc);

--- a/plugins/src/search/config.ron
+++ b/plugins/src/search/config.ron
@@ -11,11 +11,13 @@
       )
     ),
     (
-      pattern: StartsWithKeyword(["="]),
-      split: Regex("=|\\s+"),
+      pattern: StartsWith(["="]),
+      split: Regex("^="),
       action: (
-        query_command: "qalc -u8 -set 'maxdeci 9' -t $KEYWORDS",
-        run_command: "/bin/bash -c 'wl-copy \"$CAPTURE1\" && notify-send \"Copied to clipboard\"'",
+        query_command: "qalc -u8 -set 'maxdeci 9' -t $KEYWORD1",
+        result_name: "$KEYWORD1",
+        result_desc: "$OUTPUT",
+        run_command: "/bin/bash -c 'wl-copy \"$OUTPUT\" && notify-send \"Copied to clipboard\"'",
       )
     ),
     (

--- a/plugins/src/search/config.ron
+++ b/plugins/src/search/config.ron
@@ -36,7 +36,7 @@
         output_captures: "^\\s+([0-9]+)\\s+(.*)$",
         result_name: "${CAPTURE2}",
         result_desc: "${CAPTURE1}",
-        run_command: "notify-send ps",
+        run_command: "notify-send '$OUTPUT'",
       )
     ),
     (

--- a/plugins/src/search/config.ron
+++ b/plugins/src/search/config.ron
@@ -3,47 +3,48 @@
     (
       matches: ["f", "find"],
       action: (
-        name: CaptureOne("^.+/([^/]*)$"),
-        description: CaptureOne("^(.+)$"),
-        query: "fdfind --ignore-case --full-path $1 --type ${2:-file}",
-        command: "xdg-open"
+        query_command: "fdfind --ignore-case --full-path $KEYWORD1",
+        output_captures: "^(.+)/([^/]+)$",
+        result_name: "$CAPTURE2",
+        result_desc: "$CAPTURE1",
+        run_command: "xdg-open \"$OUTPUT\"",
       )
     ),
     (
       matches: ["ls"],
       action: (
-        name: Label("File"),
-        description: CaptureMany("^(.+)$", "hi ${CAPTURE}"),
-        query: "ls -1 $1",
-        command: "xdg-open"
+        query_command: "ls -1 $KEYWORD1",
+        result_name: "File",
+        result_desc: "hi $OUTPUT",
+        run_command: "xdg-open \"$KEYWORD1/$OUTPUT\""
       )
     ),
     (
       matches: ["apt"],
       action: (
-        name: CaptureOne("^([^/]+)"),
-        description: CaptureOne("/(.+)$"),
-        query: "apt list $1",
-        command: "notify-send apt"
+        query_command: "apt list $KEYWORD1",
+        output_captures: "^([^/]+)/(.+)$",
+        result_name: "$CAPTURE1",
+        result_desc: "$CAPTURE2",
+        run_command: "notify-send $OUTPUT",
       )
     ),
     (
       matches: ["ps"],
       action: (
-        name: CaptureOne("^\\s+[0-9]+\\s+(.*)$"),
-        description: CaptureOne("^\\s+([0-9]+)"),
-        query: "/bin/bash -c 'ps --sort=-pcpu -axo pid,ucmd,pcpu | head -10'",
-        command: "notify-send ps",
+        query_command: "/bin/bash -c 'ps --sort=-pcpu -axo pid,ucmd,pcpu | head -10'",
+        output_captures: "^\\s+([0-9]+)\\s+(.*)$",
+        result_name: "${CAPTURE2}",
+        result_desc: "${CAPTURE1}",
+        run_command: "notify-send ps",
       )
     ),
     (
       matches: ["drives"],
       action: (
-        name: Echo,
-        query: "lsblk -lno NAME,SIZE,MOUNTPOINTS",
-        command: "notify-send ps",
+        query_command: "lsblk -lno NAME,SIZE,MOUNTPOINTS",
+        run_command: "notify-send ps",
       )
     ),
-    
   ]
 )

--- a/plugins/src/search/config.ron
+++ b/plugins/src/search/config.ron
@@ -1,7 +1,7 @@
 (
   rules: [
     (
-      pattern: StartsWith(["f", "find"]),
+      pattern: StartsWithKeyword(["f", "find"]),
       action: (
         query_command: "fdfind --ignore-case --full-path $KEYWORD1",
         output_captures: "^(.+)/([^/]+)$",
@@ -11,16 +11,15 @@
       )
     ),
     (
-      pattern: StartsWith(["="]),
+      pattern: StartsWithKeyword(["="]),
+      split: Regex("=|\\s+"),
       action: (
         query_command: "qalc -u8 -set 'maxdeci 9' -t $KEYWORDS",
-        output_captures: "^\\s\\s(.+)$",
-        result_name: "$CAPTURE1",
         run_command: "/bin/bash -c 'wl-copy \"$CAPTURE1\" && notify-send \"Copied to clipboard\"'",
       )
     ),
     (
-      pattern: StartsWith(["ls"]),
+      pattern: StartsWithKeyword(["ls"]),
       action: (
         query_command: "ls -1 $KEYWORD1",
         result_name: "File",
@@ -29,7 +28,7 @@
       )
     ),
     (
-      pattern: StartsWith(["apt"]),
+      pattern: StartsWithKeyword(["apt"]),
       action: (
         query_command: "apt list $KEYWORD1",
         output_captures: "^([^/]+)/(.+)$",
@@ -39,7 +38,7 @@
       )
     ),
     (
-      pattern: StartsWith(["ps"]),
+      pattern: StartsWithKeyword(["ps"]),
       action: (
         query_command: "/bin/bash -c 'ps --sort=-pcpu -axo pid,ucmd,pcpu | head -10'",
         output_captures: "^\\s+([0-9]+)\\s+(.*)$",
@@ -49,7 +48,7 @@
       )
     ),
     (
-      pattern: StartsWith(["drives"]),
+      pattern: StartsWithKeyword(["drives"]),
       action: (
         query_command: "lsblk -lno NAME,SIZE,MOUNTPOINTS",
         run_command: "notify-send '$OUTPUT'",

--- a/plugins/src/search/config.ron
+++ b/plugins/src/search/config.ron
@@ -1,0 +1,22 @@
+(
+  rules: [
+    (
+      matches: ["f", "find"],
+      action: (
+        title: Capture("^.+/([^/]*)$", "File"),
+        detail: Capture("^(.+)$", "Path"),
+        query: "fdfind --ignore-case --full-path $1 --type ${2:-file}",
+        command: "xdg-open"
+      )
+    ),
+    (
+      matches: ["ls"],
+      action: (
+        title: Label("File"),
+        detail: Capture("^(.+)$", "Path"),
+        query: "ls -1 $1",
+        command: "xdg-open"
+      )
+    ),
+  ]
+)

--- a/plugins/src/search/config.ron
+++ b/plugins/src/search/config.ron
@@ -3,8 +3,8 @@
     (
       matches: ["f", "find"],
       action: (
-        title: Capture("^.+/([^/]*)$", "File"),
-        detail: Capture("^(.+)$", "Path"),
+        name: CaptureOne("^.+/([^/]*)$"),
+        description: CaptureOne("^(.+)$"),
         query: "fdfind --ignore-case --full-path $1 --type ${2:-file}",
         command: "xdg-open"
       )
@@ -12,11 +12,38 @@
     (
       matches: ["ls"],
       action: (
-        title: Label("File"),
-        detail: Capture("^(.+)$", "Path"),
+        name: Label("File"),
+        description: CaptureMany("^(.+)$", "hi ${CAPTURE}"),
         query: "ls -1 $1",
         command: "xdg-open"
       )
     ),
+    (
+      matches: ["apt"],
+      action: (
+        name: CaptureOne("^([^/]+)"),
+        description: CaptureOne("/(.+)$"),
+        query: "apt list $1",
+        command: "notify-send apt"
+      )
+    ),
+    (
+      matches: ["ps"],
+      action: (
+        name: CaptureOne("^\\s+[0-9]+\\s+(.*)$"),
+        description: CaptureOne("^\\s+([0-9]+)"),
+        query: "/bin/bash -c 'ps --sort=-pcpu -axo pid,ucmd,pcpu | head -10'",
+        command: "notify-send ps",
+      )
+    ),
+    (
+      matches: ["drives"],
+      action: (
+        name: Echo,
+        query: "lsblk -lno NAME,SIZE,MOUNTPOINTS",
+        command: "notify-send ps",
+      )
+    ),
+    
   ]
 )

--- a/plugins/src/search/config.ron
+++ b/plugins/src/search/config.ron
@@ -1,36 +1,45 @@
 (
   rules: [
     (
-      matches: ["f", "find"],
+      pattern: StartsWith(["f", "find"]),
       action: (
         query_command: "fdfind --ignore-case --full-path $KEYWORD1",
         output_captures: "^(.+)/([^/]+)$",
         result_name: "$CAPTURE2",
         result_desc: "$CAPTURE1",
-        run_command: "xdg-open \"$OUTPUT\"",
+        run_command: "xdg-open '$OUTPUT'",
       )
     ),
     (
-      matches: ["ls"],
+      pattern: StartsWith(["="]),
+      action: (
+        query_command: "qalc -u8 -set 'maxdeci 9' -t $KEYWORDS",
+        output_captures: "^\\s\\s(.+)$",
+        result_name: "$CAPTURE1",
+        run_command: "/bin/bash -c 'wl-copy \"$CAPTURE1\" && notify-send \"Copied to clipboard\"'",
+      )
+    ),
+    (
+      pattern: StartsWith(["ls"]),
       action: (
         query_command: "ls -1 $KEYWORD1",
         result_name: "File",
         result_desc: "hi $OUTPUT",
-        run_command: "xdg-open \"$KEYWORD1/$OUTPUT\""
+        run_command: "xdg-open '$KEYWORD1/$OUTPUT'"
       )
     ),
     (
-      matches: ["apt"],
+      pattern: StartsWith(["apt"]),
       action: (
         query_command: "apt list $KEYWORD1",
         output_captures: "^([^/]+)/(.+)$",
         result_name: "$CAPTURE1",
         result_desc: "$CAPTURE2",
-        run_command: "notify-send $OUTPUT",
+        run_command: "notify-send '$OUTPUT'",
       )
     ),
     (
-      matches: ["ps"],
+      pattern: StartsWith(["ps"]),
       action: (
         query_command: "/bin/bash -c 'ps --sort=-pcpu -axo pid,ucmd,pcpu | head -10'",
         output_captures: "^\\s+([0-9]+)\\s+(.*)$",
@@ -40,10 +49,10 @@
       )
     ),
     (
-      matches: ["drives"],
+      pattern: StartsWith(["drives"]),
       action: (
         query_command: "lsblk -lno NAME,SIZE,MOUNTPOINTS",
-        run_command: "notify-send ps",
+        run_command: "notify-send '$OUTPUT'",
       )
     ),
   ]

--- a/plugins/src/search/config.rs
+++ b/plugins/src/search/config.rs
@@ -86,10 +86,6 @@ fn regex_match_all() -> String {
     "^.*$".to_string()
 }
 
-fn regex_split_whitespace() -> String {
-    "\\s+".to_string()
-}
-
 fn result_echo() -> String {
     "$OUTPUT".to_string()
 }

--- a/plugins/src/search/config.rs
+++ b/plugins/src/search/config.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright © 2023 System76
+
+use serde::Deserialize;
+use slab::Slab;
+use std::collections::HashMap;
+
+#[derive(Default, Clone, Debug)]
+pub struct Config {
+    matches: HashMap<String, u32>,
+    definitions: Slab<Definition>,
+}
+
+impl Config {
+    pub fn append(&mut self, config: RawConfig) {
+        for rule in config.rules {
+            let idx = self.definitions.insert(rule.action);
+            for keyword in rule.matches {
+                self.matches.entry(keyword).or_insert(idx as u32);
+            }
+        }
+    }
+
+    pub fn get(&self, word: &str) -> Option<&Definition> {
+        self.matches
+            .get(word)
+            .and_then(|idx| self.definitions.get(*idx as usize))
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct RawConfig {
+    pub rules: Vec<Rule>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Rule {
+    pub matches: Vec<String>,
+    pub action: Definition,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub enum DisplayLine {
+    // Constant label used for each result
+    Label(String),
+
+    // A Regex capture on the result (everything in parens is captured)
+    // e.g. name: Capture("^.+/([^/]*)$"),
+    Capture(String),
+
+    // Same as Capture above, but with replace
+    // e.g. name: Replace("^(.+)$", "http://${CAPTURE}"),
+    Replace(String, String),
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Definition {
+    pub query: String,
+    pub command: String,
+    pub title: DisplayLine,
+    pub detail: DisplayLine,
+}
+
+pub fn load() -> Config {
+    eprintln!("load config");
+    let mut config = Config::default();
+
+    for path in pop_launcher::config::find("search") {
+        let string = match std::fs::read_to_string(&path) {
+            Ok(string) => string,
+            Err(why) => {
+                eprintln!("load config err A");
+                tracing::error!("failed to read config: {}", why);
+                continue;
+            }
+        };
+
+        match ron::from_str::<RawConfig>(&string) {
+            Ok(raw) => {
+                eprintln!("raw: {:?}", raw);
+                config.append(raw)
+            }
+            Err(why) => {
+                eprintln!("load config err B: {}", why);
+                tracing::error!("failed to deserialize config: {}", why);
+            }
+        }
+    }
+
+    eprintln!("load config: {:?}", config);
+
+    config
+}

--- a/plugins/src/search/config.rs
+++ b/plugins/src/search/config.rs
@@ -95,32 +95,24 @@ fn string_blank() -> String {
 }
 
 pub fn load() -> Config {
-    eprintln!("load config");
     let mut config = Config::default();
 
     for path in pop_launcher::config::find("search") {
         let string = match std::fs::read_to_string(&path) {
             Ok(string) => string,
             Err(why) => {
-                eprintln!("load config err A");
                 tracing::error!("failed to read config: {}", why);
                 continue;
             }
         };
 
         match ron::from_str::<RawConfig>(&string) {
-            Ok(raw) => {
-                eprintln!("raw: {:?}", raw);
-                config.append(raw)
-            }
+            Ok(raw) => config.append(raw),
             Err(why) => {
-                eprintln!("load config err B: {}", why);
                 tracing::error!("failed to deserialize config: {}", why);
             }
         }
     }
-
-    eprintln!("load config: {:?}", config);
 
     config
 }

--- a/plugins/src/search/config.rs
+++ b/plugins/src/search/config.rs
@@ -39,26 +39,42 @@ pub struct Rule {
     pub action: Definition,
 }
 
+/**
+ * The DisplayLine configures what to show in the results list, based on what the
+ * shell command's STDOUT produces.
+ */
 #[derive(Debug, Deserialize, Clone)]
 pub enum DisplayLine {
-    // Constant label used for each result
+    // Show nothing
+    Blank,
+
+    // Echo whatever the command outputs
+    Echo,
+
+    // Constant label to be repeated for every result
     Label(String),
 
-    // A Regex capture on the result (everything in parens is captured)
+    // A Regex capture on the result (everything in first set of parens is captured)
     // e.g. name: Capture("^.+/([^/]*)$"),
-    Capture(String),
+    CaptureOne(String),
 
     // Same as Capture above, but with replace
     // e.g. name: Replace("^(.+)$", "http://${CAPTURE}"),
-    Replace(String, String),
+    CaptureMany(String, String),
 }
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Definition {
     pub query: String,
     pub command: String,
-    pub title: DisplayLine,
-    pub detail: DisplayLine,
+    pub name: DisplayLine,
+
+    #[serde(default = "display_line_blank")]
+    pub description: DisplayLine,
+}
+
+fn display_line_blank() -> DisplayLine {
+    DisplayLine::Blank
 }
 
 pub fn load() -> Config {

--- a/plugins/src/search/config.rs
+++ b/plugins/src/search/config.rs
@@ -54,6 +54,7 @@ impl Config {
                 split: split_re,
             })
         }
+        // eprintln!("rules: {:?}", self.rules);
     }
 
     pub fn match_rule(&self, query_string: &str) -> Option<&CompiledRule> {

--- a/plugins/src/search/mod.rs
+++ b/plugins/src/search/mod.rs
@@ -5,6 +5,8 @@ use app::App;
 use futures::*;
 use pop_launcher::{async_stdin, json_input_stream, PluginResponse, Request};
 
+use crate::search::util::exec;
+
 mod app;
 mod config;
 mod util;
@@ -33,10 +35,14 @@ pub async fn main() {
             match search {
                 Event::Activate(id) => {
                     if let Some(selection) = app.search_results.get(id as usize) {
-                        let path = selection.clone();
+                        let run_command_parts = selection.clone();
                         tokio::spawn(async move {
-                            // exec(app.config.)
-                            crate::xdg_open(&path);
+                            eprintln!("run command: {:?}", run_command_parts);
+
+                            if let Some((program, args)) = run_command_parts.split_first() {
+                                // We're good to exec the command!
+                                let _ = exec(program, args, false).await;
+                            }
                         });
 
                         crate::send(&mut app.out, PluginResponse::Close).await;

--- a/plugins/src/search/mod.rs
+++ b/plugins/src/search/mod.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright © 2021 System76
+
+use app::App;
+use futures::*;
+use pop_launcher::{async_stdin, json_input_stream, PluginResponse, Request};
+
+mod app;
+mod config;
+mod util;
+
+#[derive(Debug)]
+enum Event {
+    Activate(u32),
+    Search(String),
+}
+
+pub async fn main() {
+    let (event_tx, event_rx) = flume::bounded::<Event>(8);
+
+    // Channel for cancelling searches that are in progress.
+    let (interrupt_tx, interrupt_rx) = flume::bounded::<()>(1);
+
+    let mut app = App::default();
+
+    app.cancel = Some(interrupt_rx);
+
+    let active = app.active.clone();
+
+    // Manages the external process, tracks search results, and executes activate requests
+    let search_handler = async move {
+        while let Ok(search) = event_rx.recv_async().await {
+            match search {
+                Event::Activate(id) => {
+                    if let Some(selection) = app.search_results.get(id as usize) {
+                        let path = selection.clone();
+                        tokio::spawn(async move {
+                            // exec(app.config.)
+                            crate::xdg_open(&path);
+                        });
+
+                        crate::send(&mut app.out, PluginResponse::Close).await;
+                    }
+                }
+
+                Event::Search(search) => {
+                    app.search(search).await;
+                    app.active.set(false);
+                    crate::send(&mut app.out, PluginResponse::Finished).await;
+                }
+            }
+        }
+    };
+
+    // Forwards requests to the search handler, and performs an interrupt as necessary.
+    let request_handler = async move {
+        let interrupt = || {
+            let active = active.clone();
+            let tx = interrupt_tx.clone();
+            async move {
+                if active.get() {
+                    let _ = tx.try_send(());
+                }
+            }
+        };
+
+        let mut requests = json_input_stream(async_stdin());
+
+        while let Some(result) = requests.next().await {
+            match result {
+                Ok(request) => match request {
+                    // Launch the default application with the selected file
+                    Request::Activate(id) => {
+                        event_tx.send_async(Event::Activate(id)).await?;
+                    }
+
+                    // Interrupt any active searches being performed
+                    Request::Interrupt => interrupt().await,
+
+                    // Schedule a new search process to be launched
+                    Request::Search(query) => {
+                        interrupt().await;
+
+                        event_tx.send_async(Event::Search(query.to_owned())).await?;
+                        active.set(true);
+                    }
+
+                    _ => (),
+                },
+
+                Err(why) => {
+                    tracing::error!("malformed JSON input: {}", why);
+                }
+            }
+        }
+
+        Ok::<(), flume::SendError<Event>>(())
+    };
+
+    let _ = futures::future::join(request_handler, search_handler).await;
+}

--- a/plugins/src/search/mod.rs
+++ b/plugins/src/search/mod.rs
@@ -37,8 +37,6 @@ pub async fn main() {
                     if let Some(selection) = app.search_results.get(id as usize) {
                         let run_command_parts = selection.clone();
                         tokio::spawn(async move {
-                            eprintln!("run command: {:?}", run_command_parts);
-
                             if let Some((program, args)) = run_command_parts.split_first() {
                                 // We're good to exec the command!
                                 let _ = exec(program, args, false).await;

--- a/plugins/src/search/plugin.ron
+++ b/plugins/src/search/plugin.ron
@@ -1,0 +1,7 @@
+(
+    name: "Search",
+    description: "Syntax: { find | ... } <keywords>",
+    query: (help: "find ", priority: High),
+    bin: (path: "search"),
+    icon: Name("system-search"),
+)

--- a/plugins/src/search/util.rs
+++ b/plugins/src/search/util.rs
@@ -1,4 +1,4 @@
-use regex::Captures;
+use regex::{Captures, Regex};
 use std::io;
 use std::process::Stdio;
 use tokio::process::{Child, ChildStdout, Command};
@@ -29,15 +29,21 @@ impl From<ParseError> for InterpolateError {
     }
 }
 
-pub fn split_query(query_string: &str) -> Option<(String, Vec<String>)> {
-    let parts = shell_words::split(&query_string).ok();
-    if let Some(keywords) = parts {
-        if let Some(first) = keywords.first() {
-            return Some((first.to_owned(), keywords));
-        }
-    }
+pub fn split_query_by_shell_words(query_string: &str) -> Option<Vec<String>> {
+    shell_words::split(&query_string).ok()
+}
 
-    None
+pub fn split_query_by_regex(query_string: &str, split_re: &Regex) -> Option<Vec<String>> {
+    let keywords = split_re
+        .split(query_string)
+        .into_iter()
+        .map(|p| p.to_owned())
+        .collect::<Vec<String>>();
+    if keywords.len() > 0 {
+        Some(keywords)
+    } else {
+        None
+    }
 }
 
 pub fn interpolate_result(

--- a/plugins/src/search/util.rs
+++ b/plugins/src/search/util.rs
@@ -121,12 +121,10 @@ pub fn interpolate_run_command(
     keywords: &[String],
     captures: &Captures,
 ) -> Result<Vec<String>, InterpolateError> {
-    eprintln!("irunc 1: {} {:?}", input, keywords);
     let expanded = shellexpand::full_with_context(
         input,
         home_dir,
         |var: &str| -> Result<Option<String>, std::num::ParseIntError> {
-            eprintln!("irunc 2: {}", var);
             if var.eq("OUTPUT") {
                 Ok(Some(output.to_string()))
             } else if var.eq("QUERY") {
@@ -135,7 +133,6 @@ pub fn interpolate_run_command(
             } else if var.eq("KEYWORDS") {
                 // Just the keywords (absent the search prefix) as one string.
                 // NOTE: Whitespace may not be preserved
-                eprintln!("KEYWORDS: {}", keywords[1..].join(" "));
                 Ok(Some(keywords[1..].join(" ")))
             } else if let Some(number) = var.strip_prefix("KEYWORD") {
                 // Look up an individual keyword, e.g. $KEYWORD1, $KEYWORD2, etc.
@@ -162,7 +159,6 @@ pub fn interpolate_run_command(
 }
 
 pub async fn exec(program: &str, args: &[String], piped: bool) -> io::Result<(Child, ChildStdout)> {
-    eprintln!("exec {:?} with {:?}", program, args);
     // Closure to spawn the process
     let mut child = Command::new(program)
         .args(args)

--- a/plugins/src/search/util.rs
+++ b/plugins/src/search/util.rs
@@ -1,0 +1,132 @@
+use std::io;
+use std::process::Stdio;
+use tokio::process::{Child, ChildStdout, Command};
+
+use std::{env, fmt};
+
+use shell_words::{self, ParseError};
+use shellexpand::{self, LookupError};
+
+/**
+ *
+ * Suppose `config.ron` contains the following:
+ * (
+ *   (
+ *     matches: ["f", "find"],
+ *     action: (
+ *       title: Label("File"),
+ *       detail: Capture("^.+/([^/]*)$"),
+ *       query: "fdfind --ignore-case --glob --full-path $1 --type ${2:-file}"
+ *       command: "xdg-open"
+ *     )
+ *   ),
+ *   ...
+ * )
+ *
+ * And in the launcher frontend, the user types the following search:
+ *
+ *    "find 'My Document'"
+ *
+ * Perform an interpolation as follows:
+ *
+ * 1. Search all rules to find a match for the 'find' command
+ * 2. Construct the command-line query by interpolating the search terms:
+ *    $1: "My Document"
+ *    $2: "file" (using default)
+ * 3. Final result:
+ *    ["fdfind", "--ignore-case", "--glob", "--full-path", "My Document", "--type", "file"]
+ *
+ */
+
+fn home_dir() -> Option<String> {
+    env::var("HOME").ok()
+}
+
+#[derive(Debug)]
+pub enum InterpolateError {
+    LookupError(String),
+    SplitError,
+}
+
+impl<E: fmt::Display> From<LookupError<E>> for InterpolateError {
+    fn from(err: LookupError<E>) -> InterpolateError {
+        InterpolateError::LookupError(format!("{}", err))
+    }
+}
+impl From<ParseError> for InterpolateError {
+    fn from(_err: ParseError) -> InterpolateError {
+        InterpolateError::SplitError
+    }
+}
+
+pub fn interpolate_result(
+    input: &str,
+    vars: &[String],
+    capture: &str,
+) -> Result<String, InterpolateError> {
+    let expanded = shellexpand::full_with_context(
+        input,
+        home_dir,
+        |var: &str| -> Result<Option<String>, std::num::ParseIntError> {
+            if var.eq("QUERY") {
+                // All search terms as one arg
+                Ok(Some(vars[1..].join(" ")))
+            } else if var.eq("FULLQUERY") {
+                // All search terms (including search command) as one arg
+                Ok(Some(vars.join(" ")))
+            } else if var.eq("CAPTURE") {
+                // Use the regex capture (first set of parens in regex)
+                Ok(Some(capture.to_owned()))
+            } else {
+                // If this is a numeric variable (e.g. "$1", "$2", ...), look up the search term
+                let idx = var.parse::<usize>()?;
+                let value = vars.get(idx);
+                Ok(value.map(|s| format!("'{}'", s)))
+            }
+        },
+    )?;
+
+    Ok(expanded.to_string())
+}
+
+pub fn interpolate_command(input: &str, vars: &[String]) -> Result<Vec<String>, InterpolateError> {
+    let expanded = shellexpand::full_with_context(
+        input,
+        home_dir,
+        |var: &str| -> Result<Option<String>, std::num::ParseIntError> {
+            if var.eq("QUERY") {
+                // All search terms as one arg
+                Ok(Some(format!("'{}'", vars[1..].join(" "))))
+            } else if var.eq("FULLQUERY") {
+                // All search terms (including search command) as one arg
+                Ok(Some(format!("'{}'", vars.join(" "))))
+            } else {
+                // If this is a numeric variable (e.g. "$1", "$2", ...), look up the search term
+                let idx = var.parse::<usize>()?;
+                let value = vars.get(idx);
+                Ok(value.map(|s| format!("'{}'", s)))
+            }
+        },
+    )?;
+
+    let parts = shell_words::split(&expanded)?;
+
+    Ok(parts)
+}
+
+pub async fn exec(program: &str, args: &[String]) -> io::Result<(Child, ChildStdout)> {
+    eprintln!("exec {:?} with {:?}", program, args);
+    // Closure to spawn the process
+    let mut child = Command::new(program)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    child
+        .stdout
+        .take()
+        .map(move |stdout| (child, stdout))
+        .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "stdout pipe is missing"))
+}

--- a/plugins/src/search/util.rs
+++ b/plugins/src/search/util.rs
@@ -1,4 +1,4 @@
-use regex::Captures;
+use regex::{Captures, Regex};
 use std::io;
 use std::process::Stdio;
 use tokio::process::{Child, ChildStdout, Command};
@@ -31,7 +31,7 @@ impl From<ParseError> for InterpolateError {
 
 pub fn split_query(query_string: &str) -> Option<(String, Vec<String>)> {
     let parts = shell_words::split(&query_string).ok();
-    if let Some(mut keywords) = parts {
+    if let Some(keywords) = parts {
         if let Some(first) = keywords.first() {
             return Some((first.to_owned(), keywords));
         }

--- a/plugins/src/search/util.rs
+++ b/plugins/src/search/util.rs
@@ -1,4 +1,4 @@
-use regex::{Captures, Regex};
+use regex::Captures;
 use std::io;
 use std::process::Stdio;
 use tokio::process::{Child, ChildStdout, Command};

--- a/plugins/src/search/util.rs
+++ b/plugins/src/search/util.rs
@@ -8,37 +8,6 @@ use std::{env, fmt};
 use shell_words::{self, ParseError};
 use shellexpand::{self, LookupError};
 
-/**
- *
- * Suppose `config.ron` contains the following:
- * (
- *   (
- *     matches: ["f", "find"],
- *     action: (
- *       title: Label("File"),
- *       detail: Capture("^.+/([^/]*)$"),
- *       query: "fdfind --ignore-case --glob --full-path $1 --type ${2:-file}"
- *       command: "xdg-open"
- *     )
- *   ),
- *   ...
- * )
- *
- * And in the launcher frontend, the user types the following search:
- *
- *    "find 'My Document'"
- *
- * Perform an interpolation as follows:
- *
- * 1. Search all rules to find a match for the 'find' command
- * 2. Construct the command-line query by interpolating the search terms:
- *    $1: "My Document"
- *    $2: "file" (using default)
- * 3. Final result:
- *    ["fdfind", "--ignore-case", "--glob", "--full-path", "My Document", "--type", "file"]
- *
- */
-
 fn home_dir() -> Option<String> {
     env::var("HOME").ok()
 }
@@ -102,7 +71,7 @@ pub fn interpolate_result(
     Ok(expanded.to_string())
 }
 
-pub fn interpolate_command(
+pub fn interpolate_query_command(
     input: &str,
     query_string: &str,
     keywords: &[String],
@@ -117,11 +86,11 @@ pub fn interpolate_command(
             } else if var.eq("KEYWORDS") {
                 // Just the keywords (absent the search prefix) as one string.
                 // NOTE: Whitespace may not be preserved
-                Ok(Some(keywords[1..].join(" ")))
+                Ok(Some(format!("'{}'", keywords[1..].join(" "))))
             } else if let Some(number) = var.strip_prefix("KEYWORD") {
                 // Look up an individual keyword, e.g. $KEYWORD1, $KEYWORD2, etc.
                 let idx = number.parse::<usize>()?;
-                Ok(keywords.get(idx).cloned())
+                Ok(keywords.get(idx).map(|kw| format!("'{}'", kw)))
             } else {
                 // TODO: Add env vars
                 Ok(None)
@@ -134,13 +103,57 @@ pub fn interpolate_command(
     Ok(parts)
 }
 
-pub async fn exec(program: &str, args: &[String]) -> io::Result<(Child, ChildStdout)> {
+pub fn interpolate_run_command(
+    input: &str,
+    output: &str,
+    query_string: &str,
+    keywords: &[String],
+    captures: &Captures,
+) -> Result<Vec<String>, InterpolateError> {
+    let expanded = shellexpand::full_with_context(
+        input,
+        home_dir,
+        |var: &str| -> Result<Option<String>, std::num::ParseIntError> {
+            if var.eq("OUTPUT") {
+                Ok(Some(output.to_string()))
+            } else if var.eq("QUERY") {
+                // The full query string (i.e. all keywords, including the search prefix) as one string
+                Ok(Some(query_string.to_string()))
+            } else if var.eq("KEYWORDS") {
+                // Just the keywords (absent the search prefix) as one string.
+                // NOTE: Whitespace may not be preserved
+                Ok(Some(keywords[1..].join(" ")))
+            } else if let Some(number) = var.strip_prefix("KEYWORD") {
+                // Look up an individual keyword, e.g. $KEYWORD1, $KEYWORD2, etc.
+                let idx = number.parse::<usize>()?;
+                Ok(keywords.get(idx).cloned())
+            } else if let Some(number) = var.strip_prefix("CAPTURE") {
+                // Look up an individual regex capture, e.g. $CAPTURE0, $CAPTURE1, etc.
+                let idx = number.parse::<usize>()?;
+                if let Some(capture) = captures.get(idx) {
+                    Ok(Some(capture.as_str().to_owned()))
+                } else {
+                    Ok(None)
+                }
+            } else {
+                // TODO: Add env vars
+                Ok(None)
+            }
+        },
+    )?;
+
+    let parts = shell_words::split(&expanded)?;
+
+    Ok(parts)
+}
+
+pub async fn exec(program: &str, args: &[String], piped: bool) -> io::Result<(Child, ChildStdout)> {
     eprintln!("exec {:?} with {:?}", program, args);
     // Closure to spawn the process
     let mut child = Command::new(program)
         .args(args)
         .stdin(Stdio::null())
-        .stdout(Stdio::piped())
+        .stdout(if piped { Stdio::piped() } else { Stdio::null() })
         .stderr(Stdio::null())
         .spawn()?;
 


### PR DESCRIPTION
NOTE: This is a WORK IN PROGRESS, and is not yet ready to be merged. Looking for early feedback, as well as rust tips and improvements to memory management and/or style. Also looking for discussion around which existing launcher plugins this could/should replace, if any.

## Intro

This is a generalized "search" plugin that can be configured to pass a query from the Pop Launcher frontend to any shell command that returns results (the shell command must return one result per line).

For example, the current "find" plugin (which has 245 lines of rust code), can be implemented in about 10 lines of config, and offers more flexibility to the end user since it becomes trivial to modify the `fdfind` shell args if desired:

```ron
# ~/.local/share/pop-launcher/plugins/search/config.ron
(
  rules: [
    (
      pattern: StartsWithKeyword(["f", "find"]),
      action: (
        query_command: "fdfind --ignore-case --full-path $KEYWORD1",
        output_captures: "^(.+)/([^/]+)$",
        result_name: "$CAPTURE2",
        result_desc: "$CAPTURE1",
        run_command: "xdg-open '$OUTPUT'",
      )
    ),
  ]
)
```

The `pattern` line indicates when to match the rule. It corresponds with the "prefix" that you type into the launcher frontend. In the above example, the search plugin would begin an `fdfind` query if the user starts typing "f" or "find" into the launcher frontend.

The `result_name` and `result_desc` settings correspond to the 1st and 2nd lines of each search result (the launcher frontend can show two lines per result). The `result_name` and `result_desc` settings are optional. By default `result_name` is "$OUTPUT", and `result_desc` is blank. Keywords from the query string, and captures from the `output_captures` regex can be used as needed to format a search result for the user.

The `query_command` is the shell command to use as the query function, e.g. `fdfind` in our example above. As long as the shell command returns only one line (on STDOUT) per result, any command may be used. For example, `ls -1`, `apt list`, a [shell command that lists your address book contacts](https://github.com/francoisfreitag/mutt-gnome-contacts), etc.

Finally, the `run_command` is the command to run on the active result chosen by the user, i.e. what to do when the user presses "Enter" in the launcher frontend.

Note that variables are expanded using [shellexpand](https://docs.rs/shellexpand/latest/shellexpand/fn.env_with_context.html) and therefore can use curly braces and default values, e.g. `${KEYWORD1:-someDefault}`.

## Example Configurations

### Example 1: List hard drives

A launcher command, "drives" that shows a list of block devices:

```ron
    (
      pattern: StartsWithKeyword(["drives"]),
      action: (
        query_command: "lsblk -lno NAME,SIZE,MOUNTPOINTS",
        run_command: "notify-send '$OUTPUT'",
      )
    ),
```

<img width="360" src="https://user-images.githubusercontent.com/129/219908165-621223ac-1f24-4c44-88e1-3914381a27ce.png">

### Example 2: Show running processes

A launcher command, "ps" that lists processes, their PIDs, and how much CPU they are using. This example demonstrates using bash to write a "mini shell script" with a pipe between `ps` and `head`:

```ron
    (
      pattern: StartsWithKeyword(["ps"]),
      action: (
        query_command: "/bin/bash -c 'ps --sort=-pcpu -axo pid,ucmd,pcpu | head -10'",
        output_captures: "^\\s+([0-9]+)\\s+(.*)$",
        result_name: "${CAPTURE2}",
        result_desc: "${CAPTURE1}",
        run_command: "notify-send '$OUTPUT'",
      )
    ),
```
<img width="360" src="https://user-images.githubusercontent.com/129/219908217-768ed309-b74c-48cf-85b9-4ef47865b5c9.png">

### Example 3: Search apt packages

A launcher command, "apt" that searches for packages using glob syntax of `apt list`, e.g. "apt zu*":
```ron
    (
      pattern: StartsWithKeyword(["apt"]),
      action: (
        query_command: "apt list $KEYWORD1",
        output_captures: "^([^/]+)/(.+)$",
        result_name: "$CAPTURE1",
        result_desc: "$CAPTURE2",
        run_command: "notify-send '$OUTPUT'",
      )
    ),
```

To understand the above, it's helpful to know how the shell command `apt list [search_term]` sends results to STDOUT--one per line, in the following format:

```
$ apt list zu*
Listing... Done
zulucrypt-cli/jammy 5.7.1-2 amd64
zulucrypt-gui/jammy 5.7.1-2 amd64
zulumount-cli/jammy 5.7.1-2 amd64
zulumount-gui/jammy 5.7.1-2 amd64
zulupolkit/jammy 5.7.1-2 amd64
zulusafe-cli/jammy 5.7.1-2 amd64
zurl/jammy 1.11.1-1 amd64
zutils/jammy 1.11-1 amd64
zutty/jammy 0.11.2.20220109.192032+dfsg1-1 amd64
```
Note that "Listing... Done" is skipped, because it does not match the `output_capture`'s regular expression, which requires that a "/" must be present in the search result line.

<img width="360" src="https://user-images.githubusercontent.com/129/219846079-2bdfc31b-1521-4c4c-b897-1f473e70aeec.png">


### Example 4: Calculator

```ron
    (
      pattern: StartsWith(["="]),
      split: Regex("^="),
      action: (
        query_command: "qalc -u8 -set 'maxdeci 9' -t $KEYWORD1",
        result_name: "$KEYWORD1",
        result_desc: "$OUTPUT",
        run_command: "/bin/bash -c 'wl-copy \"$OUTPUT\" && notify-send \"Copied to clipboard\"'",
      )
    ),
```

The `split` setting is new in the example above: it allows us to split the query using a regular expression. Normally, the query is split into keywords using the default "ShellWords" algorithm, which splits on spaces but also understands things like single and double quotes (treating words enclosed in quotes as a single entity). Here, however, to enter calculator mode with an initial "=" regardless of whether a space follows the "=", we need to split the query differently. In this example, we choose to split on the initial "=", making `$KEYWORD1` absorb the remaining equation to be sent to `qalc` as input (as well as the frontend as the name).

Fixes #164 
