### PR TITLE
Add session script for rebooting into BIOS

### DIFF
--- a/scripts/session/session-bios.sh
+++ b/scripts/session/session-bios.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/sh
+#
+# name: Enter BIOS
+# icon: system-restart
+# description: Reboot into BIOS
+# keywords: bios uefi reboot restart 
+
+set -eu
+
+is_gnome() {
+  command -v dbus-send >/dev/null && \
+    command -v gnome-session-quit >/dev/null && \
+    dbus-send --print-reply --dest=org.gnome.Shell /org/gnome/Shell org.freedesktop.DBus.Properties.Get string:org.gnome.Shell string:ShellVersion >/dev/null 2>&1
+}
+
+if is_gnome; then
+  gnome-session-quit --reboot
+elif command -v systemctl >/dev/null; then
+  systemctl reboot --firmware-setup
+fi

--- a/scripts/session/session-bios.sh
+++ b/scripts/session/session-bios.sh
@@ -14,7 +14,7 @@ is_gnome() {
 }
 
 if is_gnome; then
-  gnome-session-quit --reboot
+  systemctl reboot --firmware-setup
 elif command -v systemctl >/dev/null; then
   systemctl reboot --firmware-setup
 fi


### PR DESCRIPTION
This is copied from the session-reboot.sh script but changed to reboot into BIOS, this can be handy for quickly making changes and not needing to use the BIOS key during boot. 