### PR TITLE
cosmic-toplevel: Also match by StartupWMClass

### DIFF
--- a/plugins/src/desktop_entries/mod.rs
+++ b/plugins/src/desktop_entries/mod.rs
@@ -161,7 +161,12 @@ impl<W: AsyncWrite + Unpin> App<W> {
                                 keywords: entry.keywords().map(|keywords| {
                                     keywords.split(';').map(String::from).collect()
                                 }),
-                                icon: entry.icon().map(|x| x.to_owned()),
+                                icon: Some(
+                                    entry
+                                        .icon()
+                                        .map(|x| x.to_owned())
+                                        .unwrap_or_else(|| "application-x-executable".to_string()),
+                                ),
                                 exec: exec.to_owned(),
                                 path: path.clone(),
                                 prefers_non_default_gpu: entry.prefers_non_default_gpu(),


### PR DESCRIPTION
The first commit changes the `cosmic-toplevel` plugin to always parse the desktop entries and match by the parsed `app_id` (which can be different than the file name) and parsed `StartupWMClass`.

The latter fixes icons not showing up primarily for Xwayland apps, who use the wm-class for identification, but don't always use the app-id in place. Additionally this fixes a lot of electron apps, that don't handle the app-id correctly in general up until the very latest release.

The second commit introduces the same fallback icon we are using in the `cosmic-toplevel` and `pop-shell` plugins for apps lacking an icon to the `desktop-entries` plugin as well. In case this in controversial, as this icon might now show up in places, where previously no icon was shown, this commit can easily be dropped. In my opinion is improves consistency across the plugins.