### PR TITLE
desktop_entries: Fix activate context

### DIFF
--- a/plugins/src/desktop_entries/mod.rs
+++ b/plugins/src/desktop_entries/mod.rs
@@ -237,14 +237,11 @@ impl<W: AsyncWrite + Unpin> App<W> {
                 }
             };
 
-            let response = match context {
-                0 => PluginResponse::DesktopEntry {
-                    path: entry.path.clone(),
-                    gpu_preference,
-                    action_name: (is_cosmic && context >= gpu_len)
-                        .then(|| entry.actions[(context - gpu_len) as usize].clone()),
-                },
-                _ => return,
+            let response = PluginResponse::DesktopEntry {
+                path: entry.path.clone(),
+                gpu_preference,
+                action_name: (is_cosmic && context >= gpu_len)
+                    .then(|| entry.actions[(context - gpu_len) as usize].clone()),
             };
 
             send(&mut self.tx, response).await;


### PR DESCRIPTION
Doesn't quite fix the broken context menu on gnome (that must be caused by the pop-shell extension), but required for cosmic-launcher to behave correctly...

(Sorry this took quite a few functions to fall into place to properly test this.. now it's definitely working on cosmic.)