### PR TITLE
chore: bump freedesktop-desktop-entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "freedesktop-desktop-entry"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45157175a725e81f3f594382430b6b78af5f8f72db9bd51b94f0785f80fc6d29"
+checksum = "287f89b1a3d88dd04d2b65dfec39f3c381efbcded7b736456039c4ee49d54b17"
 dependencies = [
  "dirs 3.0.2",
  "gettext-rs",


### PR DESCRIPTION
Upgrade freedesktop-desktop-entry to 0.5.1 from 0.5.0. Should fix priority ordering of desktop files.