### PR TITLE
Toplevel high priority

### DIFF
--- a/plugins/src/cosmic_toplevel/mod.rs
+++ b/plugins/src/cosmic_toplevel/mod.rs
@@ -160,8 +160,8 @@ impl<W: AsyncWrite + Unpin> App<W> {
 
         for item in &self.toplevels {
             let retain = query.is_empty()
-                || contains_pattern(&item.1.app_id, &haystack)
-                || contains_pattern(&item.1.title, &haystack);
+                || contains_pattern(&item.1.app_id.to_ascii_lowercase(), &haystack)
+                || contains_pattern(&item.1.title.to_ascii_lowercase(), &haystack);
 
             if !retain {
                 continue;

--- a/plugins/src/cosmic_toplevel/plugin.ron
+++ b/plugins/src/cosmic_toplevel/plugin.ron
@@ -1,7 +1,7 @@
 (
     name: "COSMIC Windows",
     description: "Active windows controllable via Cosmic",
-    query: (persistent: true),
+    query: (persistent: true, priority: High),
     bin: (path: "cosmic-toplevel"),
     icon: Name("focus-windows-symbolic"),
 )


### PR DESCRIPTION
This should help fix https://github.com/pop-os/cosmic-launcher/issues/121. While, I believe they do currently show up with a specific enough search, cosmic_toplevel matches are listed at the top of the list when it is set to high priority.