### PR TITLE
use free_desktop_entry to search desktop file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-    "remote.containers.dockerPath": "podman",
-    "rust-analyzer.check.overrideCommand": ["just", "check-json"]
+    // "remote.containers.dockerPath": "podman",
+    // "rust-analyzer.check.overrideCommand": ["just", "check-json"]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,7 +778,8 @@ dependencies = [
 [[package]]
 name = "freedesktop-desktop-entry"
 version = "0.5.4"
-source = "git+https://github.com/pop-os/freedesktop-desktop-entry#babe8150fe985667d3109f239f2bb6e64e703d5b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22efefb85518ed96ebe51db2faf9164028d81c60d451c81d011ce3b4f41739b2"
 dependencies = [
  "dirs 5.0.1",
  "gettext-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "freedesktop-desktop-entry"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22efefb85518ed96ebe51db2faf9164028d81c60d451c81d011ce3b4f41739b2"
+checksum = "4fefe79ec93a6aeaa938981fe3e11b4ed1b2f9deacc6bb631585bc48252d1bfa"
 dependencies = [
  "dirs 5.0.1",
  "gettext-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,15 +574,6 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
-dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
-name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
@@ -786,13 +777,14 @@ dependencies = [
 
 [[package]]
 name = "freedesktop-desktop-entry"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c201444ddafb5506fe85265b48421664ff4617e3b7090ef99e42a0070c1aead0"
+version = "0.5.4"
+source = "git+https://github.com/pop-os/freedesktop-desktop-entry#babe8150fe985667d3109f239f2bb6e64e703d5b"
 dependencies = [
- "dirs 3.0.2",
+ "dirs 5.0.1",
  "gettext-rs",
  "memchr",
+ "strsim 0.11.1",
+ "textdistance",
  "thiserror",
  "xdg",
 ]
@@ -2349,6 +2341,12 @@ dependencies = [
  "rustix 0.38.32",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "textdistance"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d321c8576c2b47e43953e9cce236550d4cd6af0a6ce518fe084340082ca6037b"
 
 [[package]]
 name = "thiserror"

--- a/justfile
+++ b/justfile
@@ -2,6 +2,9 @@ ID := 'pop-launcher'
 plugins := 'calc desktop_entries files find pop_shell pulse recent scripts terminal web cosmic_toplevel'
 
 rootdir := ''
+debug := '0'
+
+target-dir := if debug == '1' { 'target/debug' } else { 'target/release' }
 
 base-dir := if rootdir == '' {
     env_var('HOME') / '.local'
@@ -57,7 +60,7 @@ install: install-bin install-plugins install-scripts
 
 # Install pop-launcher binary
 install-bin:
-    install -Dm0755 target/release/pop-launcher-bin {{bin-path}}
+    install -Dm0755 {{target-dir}}/pop-launcher-bin {{bin-path}}
 
 # Install pop-launcher plugins
 install-plugins:

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -9,7 +9,9 @@ publish = false
 [dependencies]
 async-pidfd = "0.1.4"
 fork = "0.1.23"
-freedesktop-desktop-entry = "0.5.2"
+freedesktop-desktop-entry = { path = "../../freedesktop-desktop-entry", features = [
+    "matching",
+] }
 human_format = "1.1.0"
 human-sort = "0.2.2"
 new_mime_guess = "4.0.1"
@@ -36,7 +38,9 @@ recently-used-xbel = "1.0.0"
 
 # dependencies cosmic toplevel
 cctk = { git = "https://github.com/pop-os/cosmic-protocols", package = "cosmic-client-toolkit" }
-sctk = { package = "smithay-client-toolkit", git = "https://github.com/smithay/client-toolkit", rev = "3bed072", features = ["calloop"] }
+sctk = { package = "smithay-client-toolkit", git = "https://github.com/smithay/client-toolkit", rev = "3bed072", features = [
+    "calloop",
+] }
 
 # dependencies desktop entries
 switcheroo-control = { git = "https://github.com/pop-os/dbus-settings-bindings" }

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 async-pidfd = "0.1.4"
 fork = "0.1.23"
-freedesktop-desktop-entry = "0.5.3"
+freedesktop-desktop-entry = { git = "https://github.com/pop-os/freedesktop-desktop-entry" }
 human_format = "1.1.0"
 human-sort = "0.2.2"
 new_mime_guess = "4.0.1"

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -9,9 +9,7 @@ publish = false
 [dependencies]
 async-pidfd = "0.1.4"
 fork = "0.1.23"
-freedesktop-desktop-entry = { path = "../../freedesktop-desktop-entry", features = [
-    "matching",
-] }
+freedesktop-desktop-entry = "0.5.3"
 human_format = "1.1.0"
 human-sort = "0.2.2"
 new_mime_guess = "4.0.1"

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 async-pidfd = "0.1.4"
 fork = "0.1.23"
-freedesktop-desktop-entry = { git = "https://github.com/pop-os/freedesktop-desktop-entry" }
+freedesktop-desktop-entry = "0.5.4"
 human_format = "1.1.0"
 human-sort = "0.2.2"
 new_mime_guess = "4.0.1"

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 async-pidfd = "0.1.4"
 fork = "0.1.23"
-freedesktop-desktop-entry = "0.5.4"
+freedesktop-desktop-entry = "0.6.0"
 human_format = "1.1.0"
 human-sort = "0.2.2"
 new_mime_guess = "4.0.1"

--- a/plugins/src/cosmic_toplevel/mod.rs
+++ b/plugins/src/cosmic_toplevel/mod.rs
@@ -107,8 +107,6 @@ impl<W: AsyncWrite + Unpin> App<W> {
 
         let locales = fde::get_languages_from_env();
 
-        tracing::warn!("locale: {:?}", locales);
-
         let paths = fde::Iter::new(fde::default_paths());
 
         let desktop_entries = DesktopEntry::decode_from_paths(paths, &locales)
@@ -163,8 +161,6 @@ impl<W: AsyncWrite + Unpin> App<W> {
     async fn search(&mut self, query: &str) {
         let query = query.to_ascii_lowercase();
 
-        tracing::warn!("search: {}", query);
-
         for (handle, info) in &self.toplevels {
             let entry = if query.is_empty() {
                 fde::matching::get_best_match(
@@ -186,8 +182,6 @@ impl<W: AsyncWrite + Unpin> App<W> {
                         &[&info.app_id, &info.title],
                     );
 
-                    tracing::warn!("found: {} for {}. Score: {}", de.appid, info.app_id, score);
-
                     if score > 0.6 {
                         Some(de)
                     } else {
@@ -197,8 +191,6 @@ impl<W: AsyncWrite + Unpin> App<W> {
             };
 
             if let Some(de) = entry {
-                tracing::warn!("match: entry: {} with query: {}", info.app_id, query);
-
                 let icon_name = if let Some(icon) = de.icon() {
                     Cow::Owned(icon.to_owned())
                 } else {

--- a/plugins/src/cosmic_toplevel/mod.rs
+++ b/plugins/src/cosmic_toplevel/mod.rs
@@ -109,7 +109,7 @@ impl<W: AsyncWrite + Unpin> App<W> {
 
         let paths = fde::Iter::new(fde::default_paths());
 
-        let desktop_entries = DesktopEntry::decode_from_paths(paths, &locales)
+        let desktop_entries = DesktopEntry::from_paths(paths, &locales)
             .filter_map(|e| e.ok())
             .collect::<Vec<_>>();
 

--- a/plugins/src/desktop_entries/mod.rs
+++ b/plugins/src/desktop_entries/mod.rs
@@ -101,7 +101,7 @@ impl<W: AsyncWrite + Unpin> App<W> {
             let src = PathSource::guess_from(&path);
             if let Ok(bytes) = std::fs::read_to_string(&path) {
                 if let Ok(entry) =
-                    DesktopEntry::decode_from_str(&path, &bytes, &get_languages_from_env())
+                    DesktopEntry::from_str(&path, &bytes, &get_languages_from_env())
                 {
                     // Do not show if our desktop is defined in `NotShowIn`.
                     if let Some(not_show_in) = entry.desktop_entry("NotShowIn") {

--- a/plugins/src/desktop_entries/mod.rs
+++ b/plugins/src/desktop_entries/mod.rs
@@ -2,7 +2,7 @@
 // Copyright © 2021 System76
 
 use crate::*;
-use freedesktop_desktop_entry::{default_paths, DesktopEntry, Iter as DesktopIter, PathSource};
+use freedesktop_desktop_entry::{default_paths, get_languages_from_env, DesktopEntry, Iter as DesktopIter, PathSource};
 use futures::StreamExt;
 use pop_launcher::*;
 use std::borrow::Cow;
@@ -100,7 +100,7 @@ impl<W: AsyncWrite + Unpin> App<W> {
         for path in DesktopIter::new(default_paths()) {
             let src = PathSource::guess_from(&path);
             if let Ok(bytes) = std::fs::read_to_string(&path) {
-                if let Ok(entry) = DesktopEntry::decode(&path, &bytes) {
+                if let Ok(entry) = DesktopEntry::decode_from_str(&path, &bytes, &get_languages_from_env()) {
                     // Do not show if our desktop is defined in `NotShowIn`.
                     if let Some(not_show_in) = entry.desktop_entry("NotShowIn") {
                         let current = ward::ward!(current.as_ref(), else { continue });
@@ -152,7 +152,7 @@ impl<W: AsyncWrite + Unpin> App<W> {
                             }
 
                             let item = Item {
-                                appid: entry.appid.to_owned(),
+                                appid: entry.appid.to_string(),
                                 name: name.to_string(),
                                 description: entry
                                     .comment(locale)

--- a/plugins/src/desktop_entries/mod.rs
+++ b/plugins/src/desktop_entries/mod.rs
@@ -5,10 +5,14 @@ use crate::*;
 use freedesktop_desktop_entry::{default_paths, get_languages_from_env, DesktopEntry, Iter as DesktopIter, PathSource};
 use futures::StreamExt;
 use pop_launcher::*;
+use utils::path_string;
 use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 use tokio::io::AsyncWrite;
+
+
+pub(crate) mod utils;
 
 #[derive(Debug, Eq)]
 struct Item {
@@ -376,20 +380,6 @@ fn current_desktop() -> Option<String> {
             x
         }
     })
-}
-
-fn path_string(source: &PathSource) -> Cow<'static, str> {
-    match source {
-        PathSource::Local | PathSource::LocalDesktop => "Local".into(),
-        PathSource::LocalFlatpak => "Flatpak".into(),
-        PathSource::LocalNix => "Nix".into(),
-        PathSource::Nix => "Nix (System)".into(),
-        PathSource::System => "System".into(),
-        PathSource::SystemLocal => "Local (System)".into(),
-        PathSource::SystemFlatpak => "Flatpak (System)".into(),
-        PathSource::SystemSnap => "Snap (System)".into(),
-        PathSource::Other(other) => Cow::Owned(other.clone()),
-    }
 }
 
 async fn try_get_gpus() -> Option<Vec<switcheroo_control::Gpu>> {

--- a/plugins/src/desktop_entries/utils.rs
+++ b/plugins/src/desktop_entries/utils.rs
@@ -25,9 +25,8 @@ pub fn get_description<'a>(de: &'a DesktopEntry<'a>, locales: &[String]) -> Stri
 
     let desc_source = path_string(&path_source).to_string();
 
-    let locale = locales.get(0).map(|e| e.as_str());
-
-    match de.comment(locale) {
+  
+    match de.comment(locales) {
         Some(desc) => {
             if desc.is_empty() {
                 desc_source

--- a/plugins/src/desktop_entries/utils.rs
+++ b/plugins/src/desktop_entries/utils.rs
@@ -1,0 +1,40 @@
+//! Reusable functions for desktop entries
+
+use std::borrow::Cow;
+
+use freedesktop_desktop_entry::{DesktopEntry, PathSource};
+
+// todo: subscriptions with notify
+
+pub fn path_string(source: &PathSource) -> Cow<'static, str> {
+    match source {
+        PathSource::Local | PathSource::LocalDesktop => "Local".into(),
+        PathSource::LocalFlatpak => "Flatpak".into(),
+        PathSource::LocalNix => "Nix".into(),
+        PathSource::Nix => "Nix (System)".into(),
+        PathSource::System => "System".into(),
+        PathSource::SystemLocal => "Local (System)".into(),
+        PathSource::SystemFlatpak => "Flatpak (System)".into(),
+        PathSource::SystemSnap => "Snap (System)".into(),
+        PathSource::Other(other) => Cow::Owned(other.clone()),
+    }
+}
+
+pub fn get_description<'a>(de: &'a DesktopEntry<'a>, locales: &[String]) -> String {
+    let path_source = PathSource::guess_from(&de.path);
+
+    let desc_source = path_string(&path_source).to_string();
+
+    let locale = locales.get(0).map(|e| e.as_str());
+
+    match de.comment(locale) {
+        Some(desc) => {
+            if desc.is_empty() {
+                desc_source
+            } else {
+                format!("{} - {}", desc_source, desc)
+            }
+        }
+        None => desc_source,
+    }
+}

--- a/plugins/src/pop_shell/mod.rs
+++ b/plugins/src/pop_shell/mod.rs
@@ -2,7 +2,7 @@
 // Copyright © 2021 System76
 
 use crate::*;
-use freedesktop_desktop_entry as fde;
+use freedesktop_desktop_entry::{self as fde, get_languages_from_env};
 use futures::StreamExt;
 use pop_launcher::*;
 use serde::{Deserialize, Serialize};
@@ -139,7 +139,7 @@ impl<W: AsyncWrite + Unpin> App<W> {
                     if let Some(name) = path.file_stem() {
                         if desktop_entry == name {
                             if let Ok(data) = fs::read_to_string(path) {
-                                if let Ok(entry) = fde::DesktopEntry::decode(path, &data) {
+                                if let Ok(entry) = fde::DesktopEntry::decode_from_str(path, &data, &get_languages_from_env()) {
                                     if let Some(icon) = entry.icon() {
                                         icon_name = Cow::Owned(icon.to_owned());
                                     }

--- a/plugins/src/pop_shell/mod.rs
+++ b/plugins/src/pop_shell/mod.rs
@@ -139,7 +139,7 @@ impl<W: AsyncWrite + Unpin> App<W> {
                     if let Some(name) = path.file_stem() {
                         if desktop_entry == name {
                             if let Ok(data) = fs::read_to_string(path) {
-                                if let Ok(entry) = fde::DesktopEntry::decode_from_str(path, &data, &get_languages_from_env()) {
+                                if let Ok(entry) = fde::DesktopEntry::from_str(path, &data, &get_languages_from_env()) {
                                     if let Some(icon) = entry.icon() {
                                         icon_name = Cow::Owned(icon.to_owned());
                                     }

--- a/plugins/src/terminal/mod.rs
+++ b/plugins/src/terminal/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // Copyright © 2021 System76
 
+use freedesktop_desktop_entry::get_languages_from_env;
 use futures::prelude::*;
 use pop_launcher::*;
 use std::path::PathBuf;
@@ -123,7 +124,7 @@ fn detect_terminal() -> (PathBuf, &'static str) {
         freedesktop_desktop_entry::Iter::new(freedesktop_desktop_entry::default_paths())
             .filter_map(|path| {
                 std::fs::read_to_string(&path).ok().and_then(|input| {
-                    DesktopEntry::decode(&path, &input).ok().and_then(|de| {
+                    DesktopEntry::decode_from_str(&path, &input, &get_languages_from_env()).ok().and_then(|de| {
                         if de.no_display()
                             || de
                                 .categories()

--- a/plugins/src/terminal/mod.rs
+++ b/plugins/src/terminal/mod.rs
@@ -124,7 +124,7 @@ fn detect_terminal() -> (PathBuf, &'static str) {
         freedesktop_desktop_entry::Iter::new(freedesktop_desktop_entry::default_paths())
             .filter_map(|path| {
                 std::fs::read_to_string(&path).ok().and_then(|input| {
-                    DesktopEntry::decode_from_str(&path, &input, &get_languages_from_env()).ok().and_then(|de| {
+                    DesktopEntry::from_str(&path, &input, &get_languages_from_env()).ok().and_then(|de| {
                         if de.no_display()
                             || de
                                 .categories()


### PR DESCRIPTION
This depend on https://github.com/pop-os/freedesktop-desktop-entry/pull/15.

This will have the benefit of
- one api to get all desktop files
- cache them in your struct without a wrapper
- one api to search desktop files
- localisation support for searching entries

Currently, this works really great. The searching function still need refinement, like decide what fields to include in the search, give some field more weight, ect. But any improvement will benefit all cosmic component now.

Also, idk it it's possible yet, but it will be nice to give the returned response a score so that good matches get displayed first. I think this should be managed in the frontend since there can be multiple plugin at once, but i'm not sure.