### PR TITLE
Use a single codegen-unit for compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde_json.workspace = true
 serde_with.workspace = true
 
 [profile.release]
+codegen-units = 1
 lto = "fat"
 panic = "abort"
 


### PR DESCRIPTION
Use a single codegen-unit for compilation
as suggested in
https://nnethercote.github.io/perf-book/build-configuration.html#codegen-units

to achieve reproducible builds.
It can also enhance optimizations of the produced binary.

This patch was done while working on reproducible builds for openSUSE, sponsored by the NLnet NGI0 fund.