### PR TITLE
justfile: Use relative links for DESTDIR style installs

### DIFF
--- a/justfile
+++ b/justfile
@@ -70,7 +70,7 @@ install-plugins:
         dest={{plugin-dir}}${plugin}
         mkdir -p ${dest}
         install -Dm0644 plugins/src/${plugin}/*.ron ${dest}
-        ln -sf {{bin-path}} {{plugin-dir}}${plugin}/$(echo ${plugin} | sed 's/_/-/')
+        ln -srf {{bin-path}} {{plugin-dir}}${plugin}/$(echo ${plugin} | sed 's/_/-/')
     done
 
 # Install pop-launcher scripts


### PR DESCRIPTION
This resolves an issue with Serpent OS when the installed plugin links point back to `/mason/install/usr/bin/pop-launcher`

Note, the AUR git pkg also uses a bit of a hack to rectify this, so lets just make it the default behaviour.

Serpent recipe change: https://github.com/serpent-os/recipes/commit/a607b85794069e2912a4a7684223fff6422f8119
Build log: https://dash.serpentos.com/logs/892/build.log