### PR TITLE
readme: fix Response JSON equivalent types

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,8 @@ pub enum Response {
 #### JSON Equivalent
 
 - `"Close"`
-- `{ "DesktopEntry": string }`
+- `{ "Context": { "id": number, "options": Array<ContextOption> }}`
+- `{ "DesktopEntry": { "path": string, "gpu_preference": GpuPreference }}`
 - `{ "Update": Array<SearchResult>}`
 - `{ "Fill": string }`
 


### PR DESCRIPTION
The JSON equivalent types did not match the Rust types in the
documentation. Fix the JSON equivalents to match the Rust type, which is
what the program actually sends.
