### PR TITLE
Allow desktop entries with shell URL handlers to correctly display in launcher

### DIFF
--- a/plugins/src/desktop_entries/mod.rs
+++ b/plugins/src/desktop_entries/mod.rs
@@ -78,9 +78,6 @@ impl<W: AsyncWrite + Unpin> App<W> {
                     if deduplicator.contains(appid) {
                         return None;
                     }
-                    // Always cache already visited entries to allow overriding entries e.g. by
-                    // placing a modified copy in ~/.local/share/applications/
-                    deduplicator.insert(appid.to_owned());
 
                     de.name(&self.locales)?;
 
@@ -135,6 +132,13 @@ impl<W: AsyncWrite + Unpin> App<W> {
                     else if de.no_display() {
                         return None;
                     }
+
+                    // Always cache already visited entries to allow overriding entries e.g. by
+                    // placing a modified copy in ~/.local/share/applications/
+                    //
+                    // We only do this when we can add an entry to our list, otherwise we risk
+                    // ignoring user overrides or valid applications due to shell URL handlers
+                    deduplicator.insert(appid.to_owned());
 
                     Some(de)
                 })


### PR DESCRIPTION
specific example: vscode from flathub

**changes tl;dr**
- the `desktop_entries` plugin adds each appid to a dedupe check really early in the filter function
- some programs may include multiple `.desktop` files, for instance vscode including a `com.visualstudio.code.desktop` and `com.visualstudio.code-url-handler.desktop`
- if one entry otherwise fails the filter (eg: `de.no_display()` set for a URL handler) then any other entries with the same appid get ignored
- this changes that behaviour so we only ignore the appid when we've added it to our list of entries