### PR TITLE
Updating cosmic_toplevel to correctly match desktop entries in some ambiguous cases

### DIFF
--- a/plugins/src/cosmic_toplevel/mod.rs
+++ b/plugins/src/cosmic_toplevel/mod.rs
@@ -22,6 +22,7 @@ use pop_launcher::{
 };
 use std::borrow::Cow;
 use std::iter;
+use std::time::Instant;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 use self::toplevel_handler::{toplevel_handler, ToplevelAction};
@@ -188,21 +189,41 @@ impl<W: AsyncWrite + Unpin> App<W> {
                     .chain(iter::once(info.title.as_str()))
                     .collect::<Vec<_>>();
 
-                fde::matching::get_best_match(
-                    &window_words,
-                    &self.desktop_entries,
-                    fde::matching::MatchAppIdOptions::default(),
-                )
-                .and_then(|de| {
-                    let score =
-                        fde::matching::get_entry_score(&query, de, &self.locales, &window_words);
+                // if there's an exact appid match, use that instead
+                let exact_appid_match = self
+                    .desktop_entries
+                    .iter()
+                    .find(|de| de.appid == info.app_id);
+                if exact_appid_match.is_some()
+                    && fde::matching::get_entry_score(
+                        &query,
+                        exact_appid_match.unwrap(),
+                        &self.locales,
+                        &window_words,
+                    ) > 0.8
+                {
+                    exact_appid_match
+                } else {
+                    fde::matching::get_best_match(
+                        &window_words,
+                        &self.desktop_entries,
+                        fde::matching::MatchAppIdOptions::default(),
+                    )
+                    .and_then(|de| {
+                        let score = fde::matching::get_entry_score(
+                            &query,
+                            de,
+                            &self.locales,
+                            &window_words,
+                        );
 
-                    if score > 0.8 {
-                        Some(de)
-                    } else {
-                        None
-                    }
-                })
+                        if score > 0.8 {
+                            Some(de)
+                        } else {
+                            None
+                        }
+                    })
+                }
             };
 
             if let Some(de) = entry {


### PR DESCRIPTION
example:
- install `OBS` (open broadcasting software) via `cosmic-store`
  -  the `.desktop` file has a `StartupWMClass=obs`, which causes this issue
- open `cosmic-files` and create a folder called `obs`
- search for `obs`
- observe that the `cosmic-files` entry has the incorrect description/icon (but _does_ open the right window)

![image](https://github.com/user-attachments/assets/8f6e2337-dc8d-439c-b16e-a7c35cc59aff)

searching manually does indeed confirm that the wrong description / icon are being passed in:
```
{"Search":"obs"}
[ .. ]
{"Append":{"id":14,"name":"Flatpak - Free and Open Source Streaming/Recording Software","description":"obs — COSMIC Files","keywords":null,"icon":{"Name":"com.obsproject.Studio"},"exec":null,"window":[0,14]}}
```

with this fix:
```
{"Search":"obs"}
[ .. ]
{"Append":{"id":14,"name":"System","description":"obs — COSMIC Files","keywords":null,"icon":{"Name":"com.system76.CosmicFiles"},"exec":null,"window":[0,14]}}
```

there are some other edge cases for this, but this one sticks out like a sore thumb for me atm :D 

i'm struggling to fully test this since i can't seem to build a proper binary (hence just searching manually) but things _seem_ OK doing some tests that way - would appreciate a 2nd pair of eyes though!
