### PR TITLE
feat(desktop_entries): resolve icons to absolute paths if in standard locations

### DIFF
--- a/plugins/src/desktop_entries/mod.rs
+++ b/plugins/src/desktop_entries/mod.rs
@@ -9,7 +9,7 @@ use futures::StreamExt;
 use pop_launcher::*;
 use std::borrow::Cow;
 use tokio::io::AsyncWrite;
-use utils::{get_description, is_session_cosmic};
+use utils::{get_description, is_session_cosmic, resolve_icon};
 
 pub(crate) mod utils;
 
@@ -259,10 +259,7 @@ impl<W: AsyncWrite + Unpin> App<W> {
                         keywords: entry
                             .keywords(&self.locales)
                             .map(|v| v.iter().map(|e| e.to_string()).collect()),
-                        icon: entry
-                            .icon()
-                            .map(|e| Cow::Owned(e.to_string()))
-                            .map(IconSource::Name),
+                        icon: resolve_icon(entry.icon()),
                         exec: entry.exec().map(|e| e.to_string()),
                         ..Default::default()
                     });


### PR DESCRIPTION
Improves icon resolution by checking standard fallback directories like pixmaps and local user icons, handling ~ expansion and missing extensions. This fixes cases where icons for apps like Battle.net and wago.io were missing in frontends that rely on pop-launcher for icon information.

References pop-os/cosmic-epoch#2847