### PR TITLE
fix: show discrete GPU as default within cosmic context menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,7 +2386,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "switcheroo-control"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#3b86984332be2c930a3536ab714b843c851fa8ca"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#0fa672f8dadb884001ef9a251b149ed432879629"
 dependencies = [
  "zbus",
 ]

--- a/plugins/src/desktop_entries/mod.rs
+++ b/plugins/src/desktop_entries/mod.rs
@@ -299,7 +299,7 @@ impl<W: AsyncWrite + Unpin> App<W> {
 
         if let Some(gpus) = self.gpus.as_ref() {
             let default_idx = if entry.prefers_non_default_gpu() {
-                gpus.iter().position(|gpu| !gpu.default).unwrap_or(0)
+                gpus.iter().position(|gpu| gpu.discrete).unwrap_or(0)
             } else {
                 gpus.iter().position(|gpu| gpu.default).unwrap_or(0)
             };


### PR DESCRIPTION
requires https://github.com/pop-os/dbus-settings-bindings/pull/29
matches https://github.com/pop-os/cosmic-launcher/pull/399

Uses a discrete GPU when a more powerful GPU is requested using `PrefersNonDefaultGPU`

> PrefersNonDefaultGPU
> If true, the application prefers to be run on a more powerful discrete GPU if available, which we describe as “a GPU other than the default one” in this spec to avoid the need to define what a discrete GPU is and in which cases it might be considered more powerful than the default GPU. This key is only a hint and support might not be present depending on the implementation. 

https://specifications.freedesktop.org/desktop-entry/latest/recognized-keys.html

---

This PR could also do some more stuff like add a `(discreted)` / `(dedicated)` and how the GPU is selected could be tweaked, but that is best discussed in https://github.com/pop-os/cosmic-launcher/pull/399