### PR TITLE
docs: adding a table specifying which `Request` expect what `Response`

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,19 @@ pub enum PluginResponse {
 }
 ```
 
+Some commands expect the plugin to send back a response for the launcher to function correctly; others are notification-only and simply inform the plugin of an action.
+
+| Request             | Expects response? | What to send back                                                                                                                                              |
+|---------------------|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Activate**        | Yes (typical)     | `Close` to dismiss the launcher, or `DesktopEntry` to launch an app. The plugin performs the action and notifies the frontend.                                 |
+| **ActivateContext** | Yes (typical)     | Same as Activate, `Close` or `DesktopEntry` to complete the action.                                                                                            |
+| **Complete**        | Optional          | `Fill` to auto-complete the search box, if applicable.                                                                                                         |
+| **Context**         | Yes (required)    | `Context` with the id and available options. Without this, the context menu will not appear.                                                                   |
+| **Exit**            | No                | Notification only. Shut down the plugin; no response needed.                                                                                                   |
+| **Interrupt**       | No                | Notification only. No direct response required; if canceling an in-flight `Search`, that `Search` should still send `Finished` once cancellation is processed. |
+| **Quit**            | No                | Notification only. Close or dismiss the selected item (e.g. a window); no response needed.                                                                     |
+| **Search**          | Yes (required)    | `Append` for each result, then `Finished` when done. The launcher waits for `Finished` from all plugins before updating the UI.                                |
+
 #### JSON Equivalent
 
 - `{ "Append": PluginSearchResult }`,

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Some commands expect the plugin to send back a response for the launcher to func
 | **Exit**            | No                | Notification only. Shut down the plugin; no response needed.                                                                                                   |
 | **Interrupt**       | No                | Notification only. No direct response required; if canceling an in-flight `Search`, that `Search` should still send `Finished` once cancellation is processed. |
 | **Quit**            | No                | Notification only. Close or dismiss the selected item (e.g. a window); no response needed.                                                                     |
-| **Search**          | Yes (required)    | `Append` for each result, then `Finished` when done. The launcher waits for `Finished` from all plugins before updating the UI.                                |
+| **Search**          | Yes (required)    | `Append` for each result, then `Finished` when done. Still need to send a `Finished` for that Search when a new Search is requested or when an Interrupt is received before the previous one `Finished`. |
 
 #### JSON Equivalent
 


### PR DESCRIPTION
This PR is adding a table specifying which `Request` expect what `Response`, which should help plugin developers who aren't using your Rust plugin traits to not do the same mistake as I did when developing my Gopass plugin https://github.com/AnomalRoil/cosmic-gopass-plugin. 

Notice that in theory the current text of the README seems to imply that the `launcher` should always send an `Interrupt` before sending a new `Search`, but in practice in my testing, when typing "test" in `cosmic-launcher`, my plugin would not get all the `Search` and `Interrupt`, especially if my Search is a bit slow to cancel, then I would get for example: `{"Search":"gp t"}`, `"Interrupt"`, `{"Search":"gp tes"}`, `"Interrupt"`,  `{"Search":"gp test"}`, weirdly missing the `{"Search":"gp te"}` entirely if my `{"Search":"gp t"}` didn't respond to the `Interrupt` quickly enough. 
That's fine in this case, but sometimes it's the last `Search` that gets skipped, which is not so fine. 
It looks to me that the plugin shouldn't be expected to respond to an `Interrupt` with a `Finished` immediately, but in practice if it doesn't it might miss the next `Search` request.
Not sure if I'm doing something wrong of if I should open an issue somewhere? 

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

