### PR TITLE
feat: add `category_icon` field to `PluginSearchResult`

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Where `PluginSearchResult` is:
     description: string,
     keywords?: Array<string>,
     icon?: IconSource,
+    category_icon?: IconSource,
     exec?: string,
     window?: [number, number],
 }

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -617,9 +617,11 @@ impl<O: futures::Sink<Response> + Unpin> Service<O> {
                         name: meta.name.clone(),
                         description: meta.description.clone(),
                         icon: meta.icon.clone(),
-                        category_icon: plugins
-                            .get(*plugin)
-                            .and_then(|conn| conn.config.icon.clone()),
+                        category_icon: meta.category_icon.clone().or_else(|| {
+                            plugins
+                                .get(*plugin)
+                                .and_then(|conn| conn.config.icon.clone())
+                        }),
                         window: meta.window,
                     }
                 });
@@ -727,6 +729,7 @@ mod tests {
                     name: "Enter BIOS".to_string(),
                     description: "Reboot into BIOS".to_string(),
                     icon: None,
+                    category_icon: None,
                     window: None,
                     exec: None,
                     keywords: Some(vec![
@@ -744,6 +747,7 @@ mod tests {
                     name: "Restart".to_string(),
                     description: "Reboot the system".to_string(),
                     icon: None,
+                    category_icon: None,
                     window: None,
                     exec: None,
                     keywords: Some(vec![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,8 @@ pub struct PluginSearchResult {
     pub keywords: Option<Vec<String>>,
     /// Icon to display in the frontend.
     pub icon: Option<IconSource>,
+    /// Icon to display as the category icon, overriding the plugin's default icon.
+    pub category_icon: Option<IconSource>,
     /// Command that is executed by this result, used for sorting and filtering.
     pub exec: Option<String>,
     /// Designates that this search item refers to a window.


### PR DESCRIPTION
Allow individual search results to optionally override the plugin-level category icon.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [TODO_ADD_SCREENSHOTS] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

