### PR TITLE
Add window thumbnails to cosmic-toplevel search results

### DIFF
--- a/plugins/src/cosmic_toplevel/mod.rs
+++ b/plugins/src/cosmic_toplevel/mod.rs
@@ -1,13 +1,15 @@
+mod thumbnail_capture;
 mod toplevel_handler;
 
 use cctk::cosmic_protocols::toplevel_info::v1::client::zcosmic_toplevel_handle_v1::State;
+use cctk::sctk::reexports::calloop;
 use cctk::wayland_client::Proxy;
-use cctk::{sctk::reexports::calloop, toplevel_info::ToplevelInfo};
 use fde::DesktopEntry;
 use freedesktop_desktop_entry as fde;
 use toplevel_handler::ToplevelUpdate;
 use tracing::{debug, error, info, warn};
 
+use crate::cosmic_toplevel::toplevel_handler::ToplevelEntry;
 use crate::desktop_entries::utils::{get_description, is_session_cosmic};
 use crate::send;
 use futures::{
@@ -70,13 +72,42 @@ pub async fn main() {
 
                 for update in updates {
                     match update {
-                        ToplevelUpdate::Info(info) => {
+                        ToplevelUpdate::ThumbnailReady {
+                            window_id,
+                            thumbnail,
+                        } => {
+                            if let Some(toplevel) = app
+                                .toplevels
+                                .iter_mut()
+                                .find(|t| t.info.foreign_toplevel.id().protocol_id() == window_id)
+                            {
+                                toplevel.thumbnail = Some(thumbnail);
+                            } else {
+                                debug!(
+                                    "thumbnail update ignored: window_id={window_id}, no matching toplevel"
+                                );
+                            }
+                        }
+                        ToplevelUpdate::Info(mut info) => {
                             if let Some(pos) = app
                                 .toplevels
                                 .iter()
-                                .position(|t| t.foreign_toplevel == info.foreign_toplevel)
+                                .position(|t| t.info.foreign_toplevel == info.info.foreign_toplevel)
                             {
-                                if info.state.contains(&State::Activated) {
+                                let title_changed =
+                                    app.toplevels[pos].info.title != info.info.title;
+
+                                if title_changed {
+                                    info.thumbnail = None;
+
+                                    let _ = app.calloop_tx.send(ToplevelAction::RefreshThumbnail(
+                                        info.info.foreign_toplevel.clone(),
+                                    ));
+                                } else if info.thumbnail.is_none() {
+                                    info.thumbnail = app.toplevels[pos].thumbnail.clone();
+                                }
+
+                                if info.info.state.contains(&State::Activated) {
                                     app.toplevels.remove(pos);
                                     app.toplevels.push(Box::new(info));
                                 } else {
@@ -90,7 +121,7 @@ pub async fn main() {
                             if let Some(pos) = app
                                 .toplevels
                                 .iter()
-                                .position(|t| t.foreign_toplevel == foreign_toplevel)
+                                .position(|t| t.info.foreign_toplevel == foreign_toplevel)
                             {
                                 app.toplevels.remove(pos);
                                 // ignore requests for this id until after the next search
@@ -111,7 +142,7 @@ struct App<W> {
     locales: Vec<String>,
     desktop_entries: Vec<DesktopEntry>,
     ids_to_ignore: Vec<u32>,
-    toplevels: Vec<Box<ToplevelInfo>>,
+    toplevels: Vec<Box<ToplevelEntry>>,
     calloop_tx: calloop::channel::Sender<ToplevelAction>,
     tx: W,
 }
@@ -148,8 +179,8 @@ impl<W: AsyncWrite + Unpin> App<W> {
             return;
         }
         if let Some(handle) = self.toplevels.iter().find_map(|t| {
-            if t.foreign_toplevel.id().protocol_id() == id {
-                Some(t.foreign_toplevel.clone())
+            if t.info.foreign_toplevel.id().protocol_id() == id {
+                Some(t.info.foreign_toplevel.clone())
             } else {
                 None
             }
@@ -164,8 +195,8 @@ impl<W: AsyncWrite + Unpin> App<W> {
             return;
         }
         if let Some(handle) = self.toplevels.iter().find_map(|t| {
-            if t.foreign_toplevel.id().protocol_id() == id {
-                Some(t.foreign_toplevel.clone())
+            if t.info.foreign_toplevel.id().protocol_id() == id {
+                Some(t.info.foreign_toplevel.clone())
             } else {
                 None
             }
@@ -185,14 +216,14 @@ impl<W: AsyncWrite + Unpin> App<W> {
 
         for info in &self.toplevels {
             let retain = query.is_empty()
-                || contains_pattern(&info.app_id, &haystack)
-                || contains_pattern(&info.title, &haystack);
+                || contains_pattern(&info.info.app_id, &haystack)
+                || contains_pattern(&info.info.title, &haystack);
 
             if !retain {
                 continue;
             }
 
-            let appid = fde::unicase::Ascii::new(info.app_id.as_str());
+            let appid = fde::unicase::Ascii::new(info.info.app_id.as_str());
 
             let entry = fde::find_app_by_id(&self.desktop_entries, appid)
                 .map(ToOwned::to_owned)
@@ -206,9 +237,10 @@ impl<W: AsyncWrite + Unpin> App<W> {
 
             let response = PluginResponse::Append(PluginSearchResult {
                 // XXX protocol id may be re-used later
-                id: info.foreign_toplevel.id().protocol_id(),
-                window: Some((0, info.foreign_toplevel.id().protocol_id())),
-                description: info.title.clone(),
+                id: info.info.foreign_toplevel.id().protocol_id(),
+                window: Some((0, info.info.foreign_toplevel.id().protocol_id())),
+                thumbnail: info.thumbnail.clone(),
+                description: info.info.title.clone(),
                 name: get_description(&entry, &self.locales),
                 icon: Some(IconSource::Name(icon_name)),
                 ..Default::default()

--- a/plugins/src/cosmic_toplevel/thumbnail_capture.rs
+++ b/plugins/src/cosmic_toplevel/thumbnail_capture.rs
@@ -1,0 +1,248 @@
+use std::collections::HashMap;
+
+use cctk::{
+    GlobalData,
+    screencopy::{
+        CaptureOptions, CaptureSession, CaptureSource, Capturer, ScreencopyFrameData,
+        ScreencopyFrameDataExt, ScreencopySessionData, ScreencopySessionDataExt,
+    },
+    wayland_client::{Dispatch, Proxy, QueueHandle},
+    wayland_protocols::ext::{
+        foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+        image_capture_source::v1::client::ext_image_capture_source_v1::ExtImageCaptureSourceV1,
+        image_copy_capture::v1::client::ext_image_copy_capture_session_v1::ExtImageCopyCaptureSessionV1,
+    },
+};
+use pop_launcher::ThumbnailData;
+use sctk::shm::slot::{Buffer, SlotPool};
+use tracing::warn;
+
+const THUMBNAIL_TARGET_WIDTH: u32 = 160;
+
+enum ThumbnailState {
+    Pending {
+        _session: CaptureSession,
+    },
+    Capturing {
+        _session: CaptureSession,
+        pool: SlotPool,
+        buffer: Buffer,
+        width: u32,
+        height: u32,
+        stride: u32,
+    },
+    Ready(ThumbnailData),
+}
+
+pub struct ThumbnailSessionData {
+    window_id: u32,
+    session_data: ScreencopySessionData,
+}
+
+impl ThumbnailSessionData {
+    pub fn new(window_id: u32) -> Self {
+        Self {
+            window_id,
+            session_data: ScreencopySessionData::default(),
+        }
+    }
+
+    pub fn window_id(&self) -> u32 {
+        self.window_id
+    }
+}
+
+impl ScreencopySessionDataExt for ThumbnailSessionData {
+    fn screencopy_session_data(&self) -> &ScreencopySessionData {
+        &self.session_data
+    }
+}
+
+pub struct ThumbnailCaptureState {
+    cache: HashMap<u32, ThumbnailState>,
+}
+
+impl ThumbnailCaptureState {
+    pub fn new() -> Self {
+        Self {
+            cache: HashMap::new(),
+        }
+    }
+
+    pub fn thumbnail_for(
+        &mut self,
+        toplevel: &ExtForeignToplevelHandleV1,
+    ) -> Option<ThumbnailData> {
+        let id = toplevel.id().protocol_id();
+
+        match self.cache.get(&id) {
+            Some(ThumbnailState::Ready(thumbnail)) => Some(thumbnail.clone()),
+            Some(ThumbnailState::Pending { .. })
+            | Some(ThumbnailState::Capturing { .. })
+            | None => None,
+        }
+    }
+
+    pub fn request_capture<D>(
+        &mut self,
+        toplevel: &ExtForeignToplevelHandleV1,
+        capturer: &Capturer,
+        qh: &QueueHandle<D>,
+    ) where
+        D: 'static,
+        D: Dispatch<ExtImageCaptureSourceV1, GlobalData>,
+        D: Dispatch<ExtImageCopyCaptureSessionV1, ThumbnailSessionData>,
+    {
+        let id = toplevel.id().protocol_id();
+
+        if self.cache.contains_key(&id) {
+            return;
+        }
+
+        let source = CaptureSource::Toplevel(toplevel.clone());
+        let options = CaptureOptions::empty();
+
+        match capturer.create_session(&source, options, qh, ThumbnailSessionData::new(id)) {
+            Ok(session) => {
+                self.cache
+                    .insert(id, ThumbnailState::Pending { _session: session });
+            }
+            Err(error) => {
+                warn!("create_session failed: window_id={id}, error={error:?}");
+            }
+        }
+    }
+
+    pub fn mark_capturing(
+        &mut self,
+        window_id: u32,
+        session: CaptureSession,
+        pool: SlotPool,
+        buffer: Buffer,
+        width: u32,
+        height: u32,
+        stride: u32,
+    ) {
+        self.cache.insert(
+            window_id,
+            ThumbnailState::Capturing {
+                _session: session,
+                pool,
+                buffer,
+                width,
+                height,
+                stride,
+            },
+        );
+    }
+
+    pub fn mark_ready_from_capture(&mut self, window_id: u32) -> Option<ThumbnailData> {
+        let Some(state) = self.cache.remove(&window_id) else {
+            return None;
+        };
+
+        match state {
+            ThumbnailState::Capturing {
+                _session,
+                mut pool,
+                buffer,
+                width,
+                height,
+                stride,
+            } => {
+                let raw_pixels = pool.raw_data_mut(&buffer.slot());
+
+                let Some(thumbnail) =
+                    build_thumbnail_rgba(raw_pixels, width, height, stride, THUMBNAIL_TARGET_WIDTH)
+                else {
+                    warn!("failed to build thumbnail for window_id={window_id}");
+                    return None;
+                };
+
+                self.cache
+                    .insert(window_id, ThumbnailState::Ready(thumbnail.clone()));
+                Some(thumbnail)
+            }
+            other => {
+                self.cache.insert(window_id, other);
+                None
+            }
+        }
+    }
+
+    pub fn invalidate(&mut self, window_id: u32) {
+        self.cache.remove(&window_id);
+    }
+
+    pub fn clear_in_flight(&mut self, window_id: u32) {
+        if matches!(
+            self.cache.get(&window_id),
+            Some(ThumbnailState::Pending { .. } | ThumbnailState::Capturing { .. })
+        ) {
+            self.cache.remove(&window_id);
+        }
+    }
+}
+
+pub struct ThumbnailFrameData {
+    window_id: u32,
+    frame_data: ScreencopyFrameData,
+}
+
+impl ThumbnailFrameData {
+    pub fn new(window_id: u32) -> Self {
+        Self {
+            window_id,
+            frame_data: ScreencopyFrameData::default(),
+        }
+    }
+
+    pub fn window_id(&self) -> u32 {
+        self.window_id
+    }
+}
+
+impl ScreencopyFrameDataExt for ThumbnailFrameData {
+    fn screencopy_frame_data(&self) -> &ScreencopyFrameData {
+        &self.frame_data
+    }
+}
+
+fn build_thumbnail_rgba(
+    raw_pixels: &[u8],
+    src_width: u32,
+    src_height: u32,
+    src_stride: u32,
+    target_width: u32,
+) -> Option<ThumbnailData> {
+    if src_width == 0 || src_height == 0 || target_width == 0 {
+        return None;
+    }
+
+    let target_height =
+        ((target_width as u64 * src_height as u64) / src_width as u64).max(1) as u32;
+
+    let src_stride = src_stride as usize;
+    let mut pixels = Vec::with_capacity((target_width * target_height * 4) as usize);
+
+    for y in 0..target_height {
+        let src_y = (y as u64 * src_height as u64 / target_height as u64) as usize;
+
+        for x in 0..target_width {
+            let src_x = (x as u64 * src_width as u64 / target_width as u64) as usize;
+            let src_index = src_y * src_stride + src_x * 4;
+
+            if src_index + 3 >= raw_pixels.len() {
+                return None;
+            }
+
+            pixels.extend_from_slice(&raw_pixels[src_index..src_index + 4]);
+        }
+    }
+
+    Some(ThumbnailData {
+        width: target_width,
+        height: target_height,
+        pixels,
+    })
+}

--- a/plugins/src/cosmic_toplevel/toplevel_handler.rs
+++ b/plugins/src/cosmic_toplevel/toplevel_handler.rs
@@ -2,9 +2,13 @@ use std::collections::HashSet;
 
 use cctk::{
     cosmic_protocols,
+    screencopy::{
+        CaptureFrame, CaptureSession, FailureReason, Formats, Frame, ScreencopyHandler,
+        ScreencopyState,
+    },
     toplevel_info::{ToplevelInfo, ToplevelInfoHandler, ToplevelInfoState},
     toplevel_management::{ToplevelManagerHandler, ToplevelManagerState},
-    wayland_client::{self, WEnum},
+    wayland_client::{self, Proxy, WEnum, protocol::wl_shm},
     wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
 };
 use sctk::{
@@ -13,6 +17,7 @@ use sctk::{
         calloop, calloop_wayland_source::WaylandSource, client::protocol::wl_seat::WlSeat,
     },
     seat::{SeatHandler, SeatState},
+    shm::{Shm, ShmHandler, slot::SlotPool},
 };
 
 use cosmic_protocols::{
@@ -21,17 +26,28 @@ use cosmic_protocols::{
 };
 use futures::channel::mpsc::UnboundedSender;
 use sctk::registry::{ProvidesRegistryState, RegistryState};
-use tracing::warn;
+use tracing::{debug, warn};
 use wayland_client::{Connection, QueueHandle, globals::registry_queue_init};
 
 #[derive(Debug, Clone)]
 pub enum ToplevelAction {
     Activate(ExtForeignToplevelHandleV1),
     Close(ExtForeignToplevelHandleV1),
+    RefreshThumbnail(ExtForeignToplevelHandleV1),
+}
+
+#[derive(Clone)]
+pub struct ToplevelEntry {
+    pub info: ToplevelInfo,
+    pub thumbnail: Option<pop_launcher::ThumbnailData>,
 }
 
 pub enum ToplevelUpdate {
-    Info(ToplevelInfo),
+    Info(ToplevelEntry),
+    ThumbnailReady {
+        window_id: u32,
+        thumbnail: pop_launcher::ThumbnailData,
+    },
     Remove(ExtForeignToplevelHandleV1),
 }
 
@@ -43,6 +59,9 @@ struct AppData {
     toplevel_manager_state: ToplevelManagerState,
     seat_state: SeatState,
     pending_update: HashSet<ExtForeignToplevelHandleV1>,
+    thumbnail_capture: super::thumbnail_capture::ThumbnailCaptureState,
+    shm_state: Shm,
+    screencopy_state: ScreencopyState,
 }
 
 impl AppData {
@@ -136,16 +155,36 @@ impl ToplevelInfoHandler for AppData {
         _qh: &QueueHandle<Self>,
         toplevel: &ExtForeignToplevelHandleV1,
     ) {
+        self.thumbnail_capture
+            .invalidate(toplevel.id().protocol_id());
         self.pending_update.insert(toplevel.clone());
     }
 
-    fn info_done(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>) {
+    fn info_done(&mut self, conn: &Connection, qh: &QueueHandle<Self>) {
         let res = self
             .pending_update
             .drain()
             .map(|handle| match self.toplevel_info_state.info(&handle) {
-                Some(info) => ToplevelUpdate::Info(info.clone()),
-                None => ToplevelUpdate::Remove(handle),
+                Some(info) => {
+                    let capturer = self.screencopy_state.capturer().clone();
+
+                    self.thumbnail_capture
+                        .request_capture(&info.foreign_toplevel, &capturer, qh);
+
+                    if let Err(err) = conn.flush() {
+                        self.thumbnail_capture
+                            .clear_in_flight(info.foreign_toplevel.id().protocol_id());
+                        warn!("flush failed after request_capture: error={err:?}");
+                    }
+                    ToplevelUpdate::Info(ToplevelEntry {
+                        info: info.clone(),
+                        thumbnail: self.thumbnail_capture.thumbnail_for(&info.foreign_toplevel),
+                    })
+                }
+                None => {
+                    self.thumbnail_capture.invalidate(handle.id().protocol_id());
+                    ToplevelUpdate::Remove(handle)
+                }
             })
             .collect();
 
@@ -155,20 +194,171 @@ impl ToplevelInfoHandler for AppData {
     }
 }
 
+impl ShmHandler for AppData {
+    fn shm_state(&mut self) -> &mut Shm {
+        &mut self.shm_state
+    }
+}
+
+impl ScreencopyHandler for AppData {
+    fn screencopy_state(&mut self) -> &mut ScreencopyState {
+        &mut self.screencopy_state
+    }
+
+    fn init_done(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        session: &CaptureSession,
+        formats: &Formats,
+    ) {
+        let Some(data) = session.data::<super::thumbnail_capture::ThumbnailSessionData>() else {
+            warn!("init_done received without thumbnail session data");
+            return;
+        };
+
+        let window_id = data.window_id();
+
+        if !formats.shm_formats.contains(&wl_shm::Format::Abgr8888) {
+            self.thumbnail_capture.clear_in_flight(window_id);
+            debug!("capture skipped: window_id={window_id}, Abgr8888 not supported");
+            return;
+        }
+
+        let (width, height) = formats.buffer_size;
+        if width == 0 || height == 0 {
+            self.thumbnail_capture.clear_in_flight(window_id);
+            debug!(
+                "capture skipped: window_id={window_id}, invalid buffer size=({width}, {height})"
+            );
+            return;
+        }
+
+        let stride = width * 4;
+        let size = stride * height;
+
+        let mut pool = match SlotPool::new(size as usize, &self.shm_state) {
+            Ok(pool) => pool,
+            Err(err) => {
+                self.thumbnail_capture.clear_in_flight(window_id);
+                warn!("SlotPool::new failed: window_id={window_id}, error={err:?}");
+                return;
+            }
+        };
+        let buffer = match pool.create_buffer(
+            width as i32,
+            height as i32,
+            stride as i32,
+            wl_shm::Format::Abgr8888,
+        ) {
+            Ok((buffer, canvas)) => {
+                canvas.fill(0);
+                buffer
+            }
+            Err(err) => {
+                self.thumbnail_capture.clear_in_flight(window_id);
+                warn!("create_buffer failed: window_id={window_id}, error={err:?}");
+                return;
+            }
+        };
+
+        if let Err(err) = buffer.activate() {
+            self.thumbnail_capture.clear_in_flight(window_id);
+            warn!("buffer activate failed: window_id={window_id}, error={err:?}");
+            return;
+        }
+
+        session.capture(
+            buffer.wl_buffer(),
+            &[],
+            qh,
+            super::thumbnail_capture::ThumbnailFrameData::new(window_id),
+        );
+
+        self.thumbnail_capture.mark_capturing(
+            window_id,
+            session.clone(),
+            pool,
+            buffer,
+            width,
+            height,
+            stride,
+        );
+
+        if let Err(err) = conn.flush() {
+            self.thumbnail_capture.clear_in_flight(window_id);
+            warn!("flush failed after capture: window_id={window_id}, error={err:?}");
+        }
+    }
+
+    fn stopped(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, session: &CaptureSession) {
+        if let Some(data) = session.data::<super::thumbnail_capture::ThumbnailSessionData>() {
+            self.thumbnail_capture.clear_in_flight(data.window_id());
+            debug!("thumbnail capture stopped: window_id={}", data.window_id());
+        } else {
+            debug!("thumbnail capture stopped without session data");
+        }
+    }
+
+    fn ready(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        frame: &CaptureFrame,
+        _metadata: Frame,
+    ) {
+        if let Some(data) = frame.data::<super::thumbnail_capture::ThumbnailFrameData>() {
+            let window_id = data.window_id();
+            if let Some(thumbnail) = self.thumbnail_capture.mark_ready_from_capture(window_id)
+                && let Err(err) = self.tx.unbounded_send(vec![ToplevelUpdate::ThumbnailReady {
+                    window_id,
+                    thumbnail,
+                }])
+            {
+                warn!("{err}");
+            }
+        } else {
+            warn!("ready received without thumbnail frame data");
+        }
+    }
+
+    fn failed(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        frame: &CaptureFrame,
+        reason: WEnum<FailureReason>,
+    ) {
+        if let Some(data) = frame.data::<super::thumbnail_capture::ThumbnailFrameData>() {
+            self.thumbnail_capture.clear_in_flight(data.window_id());
+            debug!(
+                "thumbnail capture failed: window_id={}, reason={reason:?}",
+                data.window_id()
+            );
+        } else {
+            debug!("thumbnail capture failed without frame data: reason={reason:?}");
+        }
+    }
+}
+
 pub(crate) fn toplevel_handler(
     tx: UnboundedSender<Vec<ToplevelUpdate>>,
     rx: calloop::channel::Channel<ToplevelAction>,
 ) -> anyhow::Result<()> {
     let conn = Connection::connect_to_env()?;
+    let conn_for_actions = conn.clone();
+
     let (globals, event_queue) = registry_queue_init(&conn)?;
     let mut event_loop = calloop::EventLoop::<AppData>::try_new()?;
     let qh = event_queue.handle();
+    let qh_for_actions = qh.clone();
+
     let wayland_source = WaylandSource::new(conn, event_queue);
     let handle = event_loop.handle();
 
     handle.insert_source(wayland_source, |_, q, state| q.dispatch_pending(state))?;
 
-    let _ = handle.insert_source(rx, |event, _, state| match event {
+    let _ = handle.insert_source(rx, move |event, _, state| match event {
         calloop::channel::Event::Msg(req) => match req {
             ToplevelAction::Activate(handle) => {
                 let manager = &state.toplevel_manager_state.manager;
@@ -183,6 +373,24 @@ pub(crate) fn toplevel_handler(
                 let manager = &state.toplevel_manager_state.manager;
                 if let Some(cosmic_toplevel) = state.cosmic_toplevel_for_foreign(&handle) {
                     manager.close(cosmic_toplevel);
+                }
+            }
+            ToplevelAction::RefreshThumbnail(handle) => {
+                let window_id = handle.id().protocol_id();
+
+                state.thumbnail_capture.invalidate(window_id);
+
+                let capturer = state.screencopy_state.capturer().clone();
+
+                state
+                    .thumbnail_capture
+                    .request_capture(&handle, &capturer, &qh_for_actions);
+
+                if let Err(err) = conn_for_actions.flush() {
+                    state.thumbnail_capture.clear_in_flight(window_id);
+                    warn!(
+                        "flush failed after RefreshThumbnail: window_id={window_id}, error={err:?}"
+                    );
                 }
             }
         },
@@ -200,6 +408,9 @@ pub(crate) fn toplevel_handler(
         toplevel_manager_state: ToplevelManagerState::new(&registry_state, &qh),
         registry_state,
         pending_update: HashSet::new(),
+        thumbnail_capture: super::thumbnail_capture::ThumbnailCaptureState::new(),
+        shm_state: Shm::bind(&globals, &qh).expect("failed to bind shm"),
+        screencopy_state: ScreencopyState::new(&globals, &qh),
     };
 
     loop {
@@ -214,3 +425,5 @@ sctk::delegate_seat!(AppData);
 sctk::delegate_registry!(AppData);
 cctk::delegate_toplevel_info!(AppData);
 cctk::delegate_toplevel_manager!(AppData);
+sctk::delegate_shm!(AppData);
+cctk::delegate_screencopy!(AppData);

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -621,6 +621,7 @@ impl<O: futures::Sink<Response> + Unpin> Service<O> {
                             .get(*plugin)
                             .and_then(|conn| conn.config.icon.clone()),
                         window: meta.window,
+                        thumbnail: meta.thumbnail.clone(),
                     }
                 });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,14 @@ pub enum PluginResponse {
     Finished,
 }
 
+/// Raw RGBA thumbnail data that can be displayed by a launcher frontend.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ThumbnailData {
+    pub width: u32,
+    pub height: u32,
+    pub pixels: Vec<u8>,
+}
+
 /// Search information from a plugin to be sorted and filtered by the launcher service.
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct PluginSearchResult {
@@ -111,6 +119,8 @@ pub struct PluginSearchResult {
     pub exec: Option<String>,
     /// Designates that this search item refers to a window.
     pub window: Option<(Generation, Indice)>,
+    /// Optional raw RGBA thumbnail data for this result.
+    pub thumbnail: Option<ThumbnailData>,
 }
 
 impl PluginSearchResult {
@@ -203,4 +213,12 @@ pub struct SearchResult {
     )]
     /// Designates that this search item refers to a window.
     pub window: Option<(Generation, Indice)>,
+
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::unwrap_or_skip"
+    )]
+    /// Optional raw RGBA thumbnail data for this result.
+    pub thumbnail: Option<ThumbnailData>,
 }


### PR DESCRIPTION
## Summary

This adds thumbnail support to launcher search results and to the `cosmic_toplevel` plugin.

The `cosmic_toplevel` plugin now captures Wayland toplevel windows through the COSMIC screencopy protocol, converts the captured buffer into a resized RGBA thumbnail, and attaches it to the corresponding search result.

The capture pipeline is asynchronous and cache-backed. Search result generation remains a cache read path, while screencopy requests are handled separately through toplevel updates.

Thumbnails are also refreshed when a toplevel title changes, which covers common cases such as browser tab changes.

## Changes

- Add thumbnail data to launcher search result structures
- Add optional thumbnail support to plugin search results
- Capture foreign toplevel windows through COSMIC screencopy
- Convert captured SHM buffers into resized RGBA thumbnails
- Cache thumbnails per window id
- Refresh thumbnails when a window title changes
- Keep search result generation separate from active screencopy work

## Testing

- Ran `cargo fmt`
- Ran `cargo check -p pop-launcher-plugins`
- Tested locally with `cosmic-launcher` Alt-Tab integration
- Verified that real window thumbnails are displayed instead of placeholders
- Verified thumbnail refresh behavior when switching browser tabs

## AI/LLM disclosure

ChatGPT was used only for code review and verification. No AI-generated code is included in this PR.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.