### PR TITLE
fix(cosmic_toplevel): flush toplevel updates on the events that actually fire

### DIFF
--- a/plugins/src/cosmic_toplevel/mod.rs
+++ b/plugins/src/cosmic_toplevel/mod.rs
@@ -76,7 +76,24 @@ pub async fn main() {
                                 .iter()
                                 .position(|t| t.foreign_toplevel == info.foreign_toplevel)
                             {
-                                if info.state.contains(&State::Activated) {
+                                // Promote only on the *transition* into `Activated`.
+                                //
+                                // Promoting whenever the flag is merely set is racy: on
+                                // a focus change the outgoing window can still deliver an
+                                // `Info` that carries `Activated`, which re-promotes it
+                                // above the window that just gained focus; a later event
+                                // then clears its flag in place, stranding a non-focused
+                                // window at the top of the switcher. Drain order out of
+                                // `pending_update` is a `HashSet`, so which window wins is
+                                // arbitrary. The effect is masked while the focused window
+                                // updates continuously (each update re-promotes it), and
+                                // shows up when it is idle: Alt+Tab then selects the window
+                                // you are already in and appears to do nothing.
+                                let was_activated =
+                                    app.toplevels[pos].state.contains(&State::Activated);
+                                let is_activated = info.state.contains(&State::Activated);
+
+                                if is_activated && !was_activated {
                                     app.toplevels.remove(pos);
                                     app.toplevels.push(Box::new(info));
                                 } else {

--- a/plugins/src/cosmic_toplevel/mod.rs
+++ b/plugins/src/cosmic_toplevel/mod.rs
@@ -82,8 +82,19 @@ pub async fn main() {
                                 } else {
                                     app.toplevels[pos] = Box::new(info);
                                 }
-                            } else {
+                            } else if info.state.contains(&State::Activated) {
                                 app.toplevels.push(Box::new(info));
+                            } else {
+                                // The initial enumeration after a (re)start delivers
+                                // every existing window through this branch. Append,
+                                // but never above the focused window, so the switcher
+                                // still opens on the window in use rather than on
+                                // whichever toplevel happened to enumerate last.
+                                let pos = app.toplevels.len()
+                                    - usize::from(app.toplevels.last().is_some_and(|t| {
+                                        t.state.contains(&State::Activated)
+                                    }));
+                                app.toplevels.insert(pos, Box::new(info));
                             }
                         }
                         ToplevelUpdate::Remove(foreign_toplevel) => {

--- a/plugins/src/cosmic_toplevel/toplevel_handler.rs
+++ b/plugins/src/cosmic_toplevel/toplevel_handler.rs
@@ -55,6 +55,26 @@ impl AppData {
             .cosmic_toplevel
             .as_ref()
     }
+
+    /// Drain `pending_update` and forward it to the plugin's main loop.
+    fn flush(&mut self) {
+        if self.pending_update.is_empty() {
+            return;
+        }
+
+        let res: Vec<ToplevelUpdate> = self
+            .pending_update
+            .drain()
+            .map(|handle| match self.toplevel_info_state.info(&handle) {
+                Some(info) => ToplevelUpdate::Info(info.clone()),
+                None => ToplevelUpdate::Remove(handle),
+            })
+            .collect();
+
+        if let Err(err) = self.tx.unbounded_send(res) {
+            warn!("{err}");
+        }
+    }
 }
 
 impl ProvidesRegistryState for AppData {
@@ -119,6 +139,7 @@ impl ToplevelInfoHandler for AppData {
         toplevel: &ExtForeignToplevelHandleV1,
     ) {
         self.pending_update.insert(toplevel.clone());
+        self.flush();
     }
 
     fn update_toplevel(
@@ -128,6 +149,7 @@ impl ToplevelInfoHandler for AppData {
         toplevel: &ExtForeignToplevelHandleV1,
     ) {
         self.pending_update.insert(toplevel.clone());
+        self.flush();
     }
 
     fn toplevel_closed(
@@ -136,22 +158,24 @@ impl ToplevelInfoHandler for AppData {
         _qh: &QueueHandle<Self>,
         toplevel: &ExtForeignToplevelHandleV1,
     ) {
-        self.pending_update.insert(toplevel.clone());
-    }
+        // cctk removes the toplevel from `toplevel_info_state` *after* this
+        // callback returns, so `info()` would still resolve here and `flush()`
+        // would infer an `Info` update, resurrecting the window we are being
+        // told is gone. Emit the `Remove` explicitly instead.
+        self.pending_update.remove(toplevel);
+        self.flush();
 
-    fn info_done(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>) {
-        let res = self
-            .pending_update
-            .drain()
-            .map(|handle| match self.toplevel_info_state.info(&handle) {
-                Some(info) => ToplevelUpdate::Info(info.clone()),
-                None => ToplevelUpdate::Remove(handle),
-            })
-            .collect();
-
-        if let Err(err) = self.tx.unbounded_send(res) {
+        if let Err(err) = self
+            .tx
+            .unbounded_send(vec![ToplevelUpdate::Remove(toplevel.clone())])
+        {
             warn!("{err}");
         }
+    }
+
+    // Only reached on protocol-v1 compositors; kept so those keep working.
+    fn info_done(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>) {
+        self.flush();
     }
 }
 


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

> **AI disclosure:** this change was diagnosed and drafted with AI assistance
> (Claude Code), as noted in both commit messages. The root cause was identified
> by reading the cctk and cosmic-comp sources and confirmed by instrumented
> measurement rather than inferred; I have reviewed the change, understand the
> mechanism, and have run it as my daily driver for 11 days. Happy to walk
> through any part of it in review.

---

## Problem

The `cosmic_toplevel` plugin can stop reporting windows entirely. When it does,
Alt+Tab shows stale titles and stale MRU order, or — if the plugin started while
the condition was already present — nothing at all, in which case cosmic-launcher
hides the switcher (`app.rs`: `if self.alt_tab && list.is_empty() { return self.hide(); }`)
and Alt+Tab appears dead.

## Cause

`pending_update` is drained only from `ToplevelInfoHandler::info_done`. cctk
raises that solely on `zcosmic_toplevel_info_v1::Event::Done`
(`client-toolkit/src/toplevel_info.rs:199`), and cosmic-comp sends that event
only on the falling edge of its internal `dirty` flag:

```rust
// cosmic-comp src/wayland/protocols/toplevel_info.rs
if !dirty && self.last_dirty {
    for instance in &self.instances {
        if instance.version() >= zcosmic_toplevel_info_v1::EVT_DONE_SINCE {
            instance.done();
        }
    }
}
self.last_dirty = dirty;
```

So the whole window list is gated on the compositor observing a refresh cycle in
which *no* toplevel changed. That is an aggregate quiescence signal, and any
single window that retitles on every cycle suppresses it indefinitely. A terminal
running a progress spinner (e.g. active Codex CLI running in WezTerm) is enough.

Under protocol v2+ the per-toplevel completion signal is
`ext_foreign_toplevel_handle_v1::Event::Done`, which cctk surfaces as
`new_toplevel` / `update_toplevel` / `toplevel_closed`. Those always fire.

## Measurements

COSMIC 1.0 on Pop!_OS 24.04, 28 windows open, one terminal running a spinner:

| signal | count |
| --- | --- |
| `zcosmic_toplevel_info_v1.done` (what the plugin waited for) | **0 in 300 s** |
| `ext_foreign_toplevel_handle_v1.Done` → `update_toplevel` | **944 in 6 s** |

A freshly started plugin returned **0** entries; a raw
`ext_foreign_toplevel_list_v1` client on the same socket enumerated all 28 with
correct titles, so the compositor was serving the data throughout. End to end,
`pop-launcher` searching `firefox` with ~20 Firefox windows open returned 0
window entries.

The failure mode is inverted by this change: the churn that used to starve the
list is exactly what now keeps it current.

## Changes

**1. Flush on the events that actually fire.** `info_done` is kept and delegates
to the same helper, so protocol-v1 compositors are unaffected.

`toplevel_closed` cannot use the same `info()`-based inference that `flush()`
uses: cctk removes the toplevel from `toplevel_info_state` *after* the callback
returns, so `info()` still resolves and the closed window would be re-emitted as
an `Info` update — leaving a dead entry in the switcher that cannot be activated.
It emits the `Remove` explicitly. (The previous code only avoided this by
accident, because `info_done` ran long after cctk had dropped the toplevel.)

**2. Keep the focused window at the top of a freshly built list.** The
first-sight branch appended unconditionally, and the initial enumeration after a
restart delivers every existing window through it, so whichever toplevel
enumerated last ended up at the top of the switcher. Promotion on `Activated`
only applies to toplevels already in the list, so it does not cover this case.
This commit is independent of the first and can be dropped if you would rather
handle it separately.

## Testing

Built and run against COSMIC 1.0 / cosmic-comp advertising
`zcosmic_toplevel_info_v1` v3. Same session, same moment:

```
upstream a332a3a  ->   0 entries
this branch       ->  37 entries, current titles, focused window at the top
```

Deployed on a daily-driver machine for 11 days of active use — on the order of
12 hours a day, not an idle host — with the provoking workload present
throughout: 30-40 open windows, two coding-assistant CLIs running in terminals
that retitle themselves continuously, and ~20 browser windows whose titles carry
live counters. That is close to the worst case for this bug, since it is exactly
the churn that suppresses the `done` edge.

Over that period: window list correct, titles live, MRU ordering correct,
open/close reflected immediately, no plugin panics, and `no toplevel to remove`
down from ~30 per session to ~3 per day (now only the genuine
create-then-close-before-`Info` case).

### How the third commit was found

I originally filed this PR with only the first two commits. I had measured
promote-on-transition as equivalent to the existing promote-on-flag behaviour
and did not want to propose a semantic change without evidence. To make my
daily driver match the PR exactly, I then installed that two-commit build.

The Alt+Tab no-op described in the third commit showed up within minutes. I
captured it from the running plugin (the ordering excerpt quoted in that commit
message), and it went away when the commit was restored.

The earlier "equivalent" measurement was wrong because it was taken while the
focused window was a terminal running a spinner, which re-promotes the focused
window on every title update and hides the race completely.

So the 11 days above were on a build functionally equal to all three commits
here. The two-commit variant lasted about 25 minutes before the defect surfaced.

### Launcher crash survivability

`cosmic-launcher` itself has SIGSEGV'd three times during this period. That
crash is unrelated to this plugin and predates these changes — the plugin has
neither panicked nor terminated. It is worth mentioning because of how the two
interact: before this change, a mid-session launcher respawn was effectively
fatal to the switcher, since the replacement plugin missed the initial
enumeration and Alt+Tab stayed dead or stale until the next login. With this
change the respawned plugin enumerates within milliseconds, so all three crashes
passed unnoticed.

## Related

Likely the same root cause behind pop-os/cosmic-launcher#135 (closed, but still
collecting reports), pop-os/cosmic-epoch#2422, and pop-os/cosmic-epoch#2309.
Users whose desktops go briefly quiet see it as "the order takes half a second to
update"; users with continuous title churn see a permanently frozen switcher.

There is arguably also a compositor-side issue — one busy client can suppress
`done` for every toplevel-info consumer — but this change makes the plugin
independent of that signal regardless.
